### PR TITLE
Fix build_all script for OSX and FreeBSD users

### DIFF
--- a/google/build_all.sh
+++ b/google/build_all.sh
@@ -21,7 +21,7 @@ mkdir -p "${GENERATED_PLUGINS_PATH}"
 
 # For each Google plugin, build the jar file and copy it to build/plugins
 # folder.
-for plugin_dir in $(find "${SCRIPT_PATH}" -name 'gradlew' -printf "%h\n") ; do
+for plugin_dir in $(find "${SCRIPT_PATH}" -name 'gradlew' -print0 | xargs -0 -n1 dirname | sort --unique") ; do
   plugin_name="${plugin_dir##*"${SCRIPT_PATH}/"}"
   printf "\nBuilding ${plugin_name} ...\n"
 


### PR DESCRIPTION
The build_all.sh script used a flag for the find command that was not supported on OSX and FreeBSD. This change fixes the issue.