### PR TITLE
ForServiceName added to Jupyter, Wordpress, and Jenkins

### DIFF
--- a/google/detectors/exposedui/jenkins/src/main/java/com/google/tsunami/plugins/detectors/exposedui/jenkins/JenkinsExposedUiDetector.java
+++ b/google/detectors/exposedui/jenkins/src/main/java/com/google/tsunami/plugins/detectors/exposedui/jenkins/JenkinsExposedUiDetector.java
@@ -28,6 +28,7 @@ import com.google.tsunami.common.net.http.HttpResponse;
 import com.google.tsunami.common.time.UtcClock;
 import com.google.tsunami.plugin.PluginType;
 import com.google.tsunami.plugin.VulnDetector;
+import com.google.tsunami.plugin.annotations.ForServiceName;
 import com.google.tsunami.plugin.annotations.PluginInfo;
 import com.google.tsunami.proto.DetectionReport;
 import com.google.tsunami.proto.DetectionReportList;
@@ -64,6 +65,7 @@ import org.jsoup.select.Elements;
             + " jobs that could lead to RCE.",
     author = "Tsunami Team (tsunami-dev@google.com)",
     bootstrapModule = JenkinsExposedUiDetectorBootstrapModule.class)
+@ForServiceName({"http","https"})
 public final class JenkinsExposedUiDetector implements VulnDetector {
   private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
 

--- a/google/detectors/exposedui/jupyter/src/main/java/com/google/tsunami/plugins/detectors/exposedui/jupyter/JupyterExposedUiDetector.java
+++ b/google/detectors/exposedui/jupyter/src/main/java/com/google/tsunami/plugins/detectors/exposedui/jupyter/JupyterExposedUiDetector.java
@@ -28,6 +28,7 @@ import com.google.tsunami.common.net.http.HttpResponse;
 import com.google.tsunami.common.time.UtcClock;
 import com.google.tsunami.plugin.PluginType;
 import com.google.tsunami.plugin.VulnDetector;
+import com.google.tsunami.plugin.annotations.ForServiceName;
 import com.google.tsunami.plugin.annotations.PluginInfo;
 import com.google.tsunami.proto.DetectionReport;
 import com.google.tsunami.proto.DetectionReportList;
@@ -53,6 +54,7 @@ import javax.inject.Inject;
             + " the hosting VM at risk of RCE.",
     author = "Tsunami Team (tsunami-dev@google.com)",
     bootstrapModule = JupyterExposedUiDetectorBootstrapModule.class)
+@ForServiceName({"http","https"})
 public final class JupyterExposedUiDetector implements VulnDetector {
   private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
 

--- a/google/detectors/exposedui/wordpress/src/main/java/com/google/tsunami/plugins/detectors/exposedui/wordpress/WordPressInstallPageDetector.java
+++ b/google/detectors/exposedui/wordpress/src/main/java/com/google/tsunami/plugins/detectors/exposedui/wordpress/WordPressInstallPageDetector.java
@@ -28,6 +28,7 @@ import com.google.tsunami.common.net.http.HttpResponse;
 import com.google.tsunami.common.time.UtcClock;
 import com.google.tsunami.plugin.PluginType;
 import com.google.tsunami.plugin.VulnDetector;
+import com.google.tsunami.plugin.annotations.ForServiceName;
 import com.google.tsunami.plugin.annotations.PluginInfo;
 import com.google.tsunami.proto.DetectionReport;
 import com.google.tsunami.proto.DetectionReportList;
@@ -55,6 +56,7 @@ import org.jsoup.select.Elements;
             + " the admin password and possibly compromise the system.",
     author = "Tsunami Team (tsunami-dev@google.com)",
     bootstrapModule = WordPressInstallPageDetectorBootstrapModule.class)
+@ForServiceName({"http","https"})
 public final class WordPressInstallPageDetector implements VulnDetector {
   private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
 


### PR DESCRIPTION
This pull request fixes issue #5 by adding http and https ForServiceName annotations to Jenkins, Wordpress, and Jupyter plugins.

According to the documentation, "https" is the right service name, although nmap lists "ssl/ssl" for https ports scanned by us.
We could not test this because of issue #7, where https services are recognized as http.