### PR TITLE
modify laravel_cve_2021_3129 rootProject.name

### DIFF
--- a/community/detectors/laravel_cve_2021_3129/settings.gradle
+++ b/community/detectors/laravel_cve_2021_3129/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'cve20213129detector'
+rootProject.name = 'laravel_cve_2021_3129'

--- a/community/detectors/nacos_cve_2021_29441/settings.gradle
+++ b/community/detectors/nacos_cve_2021_29441/settings.gradle
@@ -1,2 +1,2 @@
-rootProject.name = 'CVE-2021-29441'
+rootProject.name = 'nacos_cve_2021_29441'
 


### PR DESCRIPTION
The rootProject.name and the folder name are inconsistent, causing the idea to have a double name.