### PR TITLE
Add CvssV3 Score to weak credential result

### DIFF
--- a/google/detectors/credentials/ncrack/src/main/java/com/google/tsunami/plugins/detectors/credentials/ncrack/NcrackWeakCredentialDetector.java
+++ b/google/detectors/credentials/ncrack/src/main/java/com/google/tsunami/plugins/detectors/credentials/ncrack/NcrackWeakCredentialDetector.java
@@ -163,7 +163,7 @@ public final class NcrackWeakCredentialDetector implements VulnDetector {
                             .setValue(buildVulnerabilityId(networkService)))
                     .setSeverity(DEFAULT_SEVERITY)
                     .setTitle(buildTitle(networkService))
-                    // TODO(b/145315535): determine CVSS score.
+                    .setCvssV3("7.5") // CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N
                     .setDescription(buildDescription(networkService))
                     .addAdditionalDetails(buildCredentialDetail(testCredential)))
             .build());

--- a/google/detectors/credentials/ncrack/src/test/java/com/google/tsunami/plugins/detectors/credentials/ncrack/NcrackWeakCredentialDetectorTest.java
+++ b/google/detectors/credentials/ncrack/src/test/java/com/google/tsunami/plugins/detectors/credentials/ncrack/NcrackWeakCredentialDetectorTest.java
@@ -158,6 +158,7 @@ public final class NcrackWeakCredentialDetectorTest {
                         .setDescription(
                             "Well known or weak credentials are detected for 'http' service on"
                                 + " port '80'.")
+                        .setCvssV3("7.5")
                         .addAdditionalDetails(
                             AdditionalDetail.newBuilder()
                                 .setDescription("Identified credential")
@@ -211,6 +212,7 @@ public final class NcrackWeakCredentialDetectorTest {
                         .setDescription(
                             "Well known or weak credentials are detected for 'http' service on"
                                 + " port '80'.")
+                        .setCvssV3("7.5")
                         .addAdditionalDetails(
                             AdditionalDetail.newBuilder()
                                 .setDescription("Identified credential")
@@ -240,6 +242,7 @@ public final class NcrackWeakCredentialDetectorTest {
                         .setDescription(
                             "Well known or weak credentials are detected for 'http' service on"
                                 + " port '80'.")
+                        .setCvssV3("7.5")
                         .addAdditionalDetails(
                             AdditionalDetail.newBuilder()
                                 .setDescription("Identified credential")


### PR DESCRIPTION
For weak credentials, the CVSSv3 base score:

- Vector is always N
- Complexity is always L
- Privileges required is always N
- User Interaction is always N
- Scope may be C or U, depending on permissions on target
- Confidentiality is at least L
- Integrity impact may be H, L or N depending on permissions on target
- Availability impact is N

Scope and permissions of the credentials on the target system are not available to ncrack. This PR assigns a CVE score 7.5 based on vector [CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N](https://www.first.org/cvss/calculator/3.0#CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N) to the finding. The score may be higher or lower depending on the permissions on the target system. 

The lowest possible score is 5.3 for vector CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N