### PR TITLE
Fix #297: Remove extension.isEmpty() call

### DIFF
--- a/google/fingerprinters/web/src/main/java/com/google/tsunami/plugins/fingerprinters/web/tools/FingerprintUpdater.java
+++ b/google/fingerprinters/web/src/main/java/com/google/tsunami/plugins/fingerprinters/web/tools/FingerprintUpdater.java
@@ -288,7 +288,7 @@ public final class FingerprintUpdater {
     String extension = Files.getFileExtension(Ascii.toLowerCase(relativePath));
 
     // Ignores hidden files and folders.
-    if (extension.isEmpty() || relativePath.startsWith(".") || relativePath.contains("/.")) {
+    if (relativePath.startsWith(".") || relativePath.contains("/.")) {
       return true;
     }
     if (IGNORED_EXTENTIONS.contains(extension)) {


### PR DESCRIPTION
This will allow to use file names with no extensions on the FingerPrint plugin.