### PR TITLE
Doyensec Tsunami plugins directory

### DIFF
--- a/doyensec/README.md
+++ b/doyensec/README.md
@@ -1,0 +1,21 @@
+# Doyensec Tsunami Plugins
+
+![doyensec-plugins-build](https://github.com/google/tsunami-security-scanner-plugins/workflows/doyensec-plugins-build/badge.svg)
+
+This directory contains all Tsunami plugins published by Doyensec.
+
+## Currently released plugins
+
+### Detectors
+
+
+
+## Build all plugins
+
+Use the following command to build all Doyensec released plugins:
+
+```
+./build_all.sh
+```
+
+All generated `jar` files are copied into `build/plugins` folder.

--- a/doyensec/build_all.sh
+++ b/doyensec/build_all.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+SCRIPT_PATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+GENERATED_PLUGINS_PATH="${SCRIPT_PATH}/build/plugins"
+mkdir -p "${GENERATED_PLUGINS_PATH}"
+
+# For each Doyensec plugin, build the jar file and copy it to build/plugins
+# folder.
+for plugin_dir in $(find "${SCRIPT_PATH}" -name 'gradlew' -print0 | xargs -0 -n1 dirname | sort --unique) ; do
+  plugin_name="${plugin_dir##*"${SCRIPT_PATH}/"}"
+  printf "\nBuilding ${plugin_name} ...\n"
+
+  pushd "${plugin_dir}" >/dev/null
+
+  ./gradlew build
+  cp ./build/libs/*.jar "${GENERATED_PLUGINS_PATH}"
+
+  popd >/dev/null
+done
+


### PR DESCRIPTION
This PR is to propose an addition of a dedicated `doyensec` directory for better Doyensec plugin organization as discussed on the call. It also has the build_all script to facilitate batch building of the plugins. 