### PR TITLE
Adjusting plugins to the setTrustAllCertificates change in core

### DIFF
--- a/community/detectors/argocd_exposed_ui/src/main/java/com/google/tsunami/plugins/detectors/exposedui/argocd/ExposedArgoCdApiDetector.java
+++ b/community/detectors/argocd_exposed_ui/src/main/java/com/google/tsunami/plugins/detectors/exposedui/argocd/ExposedArgoCdApiDetector.java
@@ -121,7 +121,6 @@ public final class ExposedArgoCdApiDetector implements VulnDetector {
         checkNotNull(httpClient)
             .modify()
             .setFollowRedirects(true)
-            .setTrustAllCertificates(true)
             .build();
     this.utcClock = checkNotNull(utcClock);
     this.payloadGenerator = checkNotNull(payloadGenerator);

--- a/community/detectors/metabase_cve_2023_38646/src/main/java/com/google/tsunami/plugins/detectors/cves/cve202338646/Cve202338646Detector.java
+++ b/community/detectors/metabase_cve_2023_38646/src/main/java/com/google/tsunami/plugins/detectors/cves/cve202338646/Cve202338646Detector.java
@@ -84,7 +84,7 @@ public final class Cve202338646Detector implements VulnDetector {
   Cve202338646Detector(
       @UtcClock Clock utcClock, HttpClient httpClient, PayloadGenerator payloadGenerator) {
     this.utcClock = checkNotNull(utcClock);
-    this.httpClient = checkNotNull(httpClient).modify().setTrustAllCertificates(true).build();
+    this.httpClient = checkNotNull(httpClient);
     this.payloadGenerator = checkNotNull(payloadGenerator);
   }
 

--- a/doyensec/detectors/kubernetes_rce_via_open_access/src/main/java/com/google/tsunami/plugins/detectors/rce/kubernetes/RCEInKubernetesClusterWithOpenAccessDetector.java
+++ b/doyensec/detectors/kubernetes_rce_via_open_access/src/main/java/com/google/tsunami/plugins/detectors/rce/kubernetes/RCEInKubernetesClusterWithOpenAccessDetector.java
@@ -120,10 +120,7 @@ public final class RCEInKubernetesClusterWithOpenAccessDetector implements VulnD
       throws IOException {
     this.utcClock = checkNotNull(utcClock);
 
-    // TODO: HTTPS with insecure cert fails (despite the trustAllCertificate set below) with:
-    // javax.net.ssl.SSLHandshakeException.
-    // Must run tsunami with option: --http-client-trust-all-certificates for it to take effect.
-    this.httpClient = checkNotNull(httpClient).modify().setTrustAllCertificates(true).build();
+    this.httpClient = checkNotNull(httpClient);
 
     this.payloadGenerator = checkNotNull(payloadGenerator);
     this.payloadFormatString =


### PR DESCRIPTION
Due to https://github.com/google/tsunami-security-scanner/pull/118, Tsunami Core is no longer exposing the `setTrustAllCertificates` method in the `HttpClient` interface. As a result, three plugins had to be adjusted:

- community/detectors/metabase_cve_2023_38646/src/main/java/com/google/tsunami/plugins/detectors/cves/cve202338646/Cve202338646Detector.java
- community/detectors/argocd_exposed_ui/src/main/java/com/google/tsunami/plugins/detectors/exposedui/argocd/ExposedArgoCdApiDetector.java
-  doyensec/detectors/kubernetes_rce_via_open_access/src/main/java/com/google/tsunami/plugins/detectors/rce/kubernetes/RCEInKubernetesClusterWithOpenAccessDetector.java

**This needs to be merged together with the core change.**