### PR TITLE
Mitigate False Positives in CVE-2022-33891 Detector

### DIFF
--- a/community/detectors/apache_spark_cve_2022_33891/src/main/java/com/google/tsunami/plugins/detectors/cves/cve202233891/Cve202233891VulnDetector.java
+++ b/community/detectors/apache_spark_cve_2022_33891/src/main/java/com/google/tsunami/plugins/detectors/cves/cve202233891/Cve202233891VulnDetector.java
@@ -62,7 +62,7 @@ public final class Cve202233891VulnDetector implements VulnDetector {
   private final HttpClient httpClient;
   private final PayloadGenerator payloadGenerator;
 
-  private static final short SLEEP_CMD_WAIT_DURATION_SECONDS = 5;
+  private static final short SLEEP_CMD_WAIT_DURATION_SECONDS = 15;
 
   @Inject
   Cve202233891VulnDetector(
@@ -121,7 +121,7 @@ public final class Cve202233891VulnDetector implements VulnDetector {
       logger.atInfo().log("Callback server is not available!");
       Stopwatch stopwatch = Stopwatch.createUnstarted();
       String targetUri =
-          NetworkServiceUtils.buildWebApplicationRootUrl(networkService) + "?doAs=`sleep 5`";
+          NetworkServiceUtils.buildWebApplicationRootUrl(networkService) + "?doAs=`sleep 15`";
       var request = HttpRequest.get(targetUri).withEmptyHeaders().build();
       try {
         stopwatch.start();

--- a/community/detectors/apache_spark_cve_2022_33891/src/test/java/com/google/tsunami/plugins/detectors/cves/cve202233891/Cve202233891DetectorWithoutCallbackServerTest.java
+++ b/community/detectors/apache_spark_cve_2022_33891/src/test/java/com/google/tsunami/plugins/detectors/cves/cve202233891/Cve202233891DetectorWithoutCallbackServerTest.java
@@ -97,7 +97,7 @@ public class Cve202233891DetectorWithoutCallbackServerTest {
     // It is a blind RCE, body is not important. This is a part of a valid response.
     mockWebServer.enqueue(
         new MockResponse()
-            .setBodyDelay(5, SECONDS)
+            .setBodyDelay(15, SECONDS)
             .setResponseCode(403)
             .setBody(
                 "<tr><th>SERVLET:</th><td>org.apache.spark.ui.JettyUtils$$anon$1-7439513f</td></tr>\n"));


### PR DESCRIPTION
The detection for CVE-2022-33891 (the path without callbacks) relies on sending "?doAs=`sleep 5`" as part of the payload and then waiting to see if the server takes more than 5 seconds to send a response.

This makes the detector noisy in case the (any other) server takes more than 5 seconds to respond, which has led to multiple false positives in our use-cases.

I'd remove the (without callback) branch completely, unless we can make sure Spark is behind the webserver, but I don't have a lot of context (nor a vulnerable version of Spark running) to make that call.

In the meantime, this PR raises the waiting time to 15 seconds, which mitigates the issue for our use-cases, but it might make Tsunami run slower. 

 