### PR TITLE
Enforce Scope Check in Fingerprint Updater

### DIFF
--- a/google/fingerprinters/web/src/main/java/com/google/tsunami/plugins/fingerprinters/web/tools/FingerprintUpdater.java
+++ b/google/fingerprinters/web/src/main/java/com/google/tsunami/plugins/fingerprinters/web/tools/FingerprintUpdater.java
@@ -188,6 +188,7 @@ public final class FingerprintUpdater {
             .addAllSeedingUrls(seedingUrls)
             .setMaxDepth(options.maxCrawlDepth)
             .addScopes(ScopeUtils.fromUrl(options.remoteUrl))
+            .setShouldEnforceScopeCheck(true)
             .setNetworkEndpoint(NetworkEndpoint.getDefaultInstance())
             .build();
     return crawler.crawl(crawlConfig).stream()


### PR DESCRIPTION
The fingerprint updater goes out of scope while crawling websites because the `CrawlConfig` does not explicitly call `. setShouldEnforceScopeCheck(true)`.

To reproduce the bug:
1. Create a simple index.html file with this content:
`<a href="https://example.com/">[example.com](http://example.com/)</a>`

2. Start a Python HTTP Server:
`python3 -m http.server 8080`

3. Navigate to tsunami-security-scanner-plugins/google/fingerprinters/web and run the fingerprinter:
`./gradlew :runFingerprintUpdater --args="--software-name=foo --fingerprint-data-path=/tmp/foo.json --init --version=1.0 --local-repo-path /tmp/foo --remote-url=http://localhost:8080/"`

4. Check the logs:
```
[...]
INFO: Sending HTTP 'GET' request to 'http://localhost:8080/'.
Feb 06, 2025 1:49:35 AM com.google.tsunami.common.net.http.OkHttpHttpClient parseResponse
INFO: Received HTTP response with code '200' for request to 'http://localhost:8080/'.
Feb 06, 2025 1:49:35 AM com.google.tsunami.plugins.fingerprinters.web.crawl.SimpleCrawlAction lambda$compute$0
INFO: SimpleCrawlAction visited target 'http://localhost:808/0' with method 'GET' at depth '0', response code: 200.
Feb 06, 2025 1:49:35 AM com.google.tsunami.common.net.http.OkHttpHttpClient send
INFO: Sending HTTP 'GET' request to 'https://example.com/'.
Feb 06, 2025 1:49:35 AM com.google.tsunami.common.net.http.OkHttpHttpClient parseResponse
INFO: Received HTTP response with code '200' for request to 'https://example.com/'.
Feb 06, 2025 1:49:35 AM com.google.tsunami.plugins.fingerprinters.web.crawl.SimpleCrawlAction lambda$compute$0
INFO: SimpleCrawlAction visited target 'https://example.com/' with method 'GET' at depth '1', response code: 200.
Feb 06, 2025 1:49:35 AM com.google.tsunami.common.net.http.OkHttpHttpClient send
INFO: Sending HTTP 'GET' request to 'https://www.iana.org/domains/example'.
Feb 06, 2025 1:49:36 AM com.google.tsunami.common.net.http.OkHttpHttpClient parseResponse
INFO: Received HTTP response with code '301' for request to 'https://www.iana.org/domains/example'.
Feb 06, 2025 1:49:36 AM com.google.tsunami.plugins.fingerprinters.web.crawl.SimpleCrawlAction lambda$compute$0
INFO: SimpleCrawlAction visited target 'https://www.iana.org/domains/example' with method 'GET' at depth '2', response code: 301.
Feb 06, 2025 1:49:36 AM com.google.tsunami.common.net.http.OkHttpHttpClient send
INFO: Sending HTTP 'GET' request to 'http://www.iana.org/help/example-domains'.
[...]
```