### PR TITLE
feat: Add MLflow weak credential detector plugin

### DIFF
--- a/plugins/mlflow_weak_credential_detector/README.md
+++ b/plugins/mlflow_weak_credential_detector/README.md
@@ -1,0 +1,3 @@
+# MLflow Weak Credential Detector Plugin
+
+This Tsunami plugin detects weak default credentials in MLflow instances.

--- a/plugins/mlflow_weak_credential_detector/build.gradle
+++ b/plugins/mlflow_weak_credential_detector/build.gradle
@@ -1,0 +1,94 @@
+plugins {
+    id 'java-library'
+    id 'com.google.protobuf' version '0.9.4' // Or a recent compatible version
+    id 'com.github.johnrengelman.shadow' version '7.1.2' // Or a recent compatible version
+}
+
+repositories {
+    mavenCentral()
+    google() // For Tsunami artifacts if they are published to Google's Maven repo
+}
+
+// Replace with the latest Tsunami version if known, otherwise use a placeholder
+// It's often good practice to manage versions in gradle.properties or a BOM
+def tsunamiVersion = '0.20.0' // Example version, adjust as needed
+
+dependencies {
+    api "com.google.tsunami:plugin-parent:${tsunamiVersion}"
+    api "com.google.tsunami:tsunami-plugin:${tsunamiVersion}"
+    api "com.google.tsunami:tsunami-proto:${tsunamiVersion}"
+
+    implementation 'com.google.guava:guava:32.1.3-jre' // Use a recent version
+    implementation 'com.google.protobuf:protobuf-java:3.25.1' // Use a recent version
+    implementation 'com.google.flogger:google-flogger:0.8.1' // Use a recent version
+    implementation 'javax.inject:javax.inject:1'
+    implementation 'com.google.auto.value:auto-value-annotations:1.10.4' // Use a recent version
+    annotationProcessor 'com.google.auto.value:auto-value:1.10.4' // Use a recent version
+
+    // For HTTP client capabilities
+    implementation "com.google.tsunami:tsunami-common:${tsunamiVersion}"
+
+
+    testImplementation 'junit:junit:4.13.2'
+    testImplementation 'com.google.truth:truth:1.1.5' // Use a recent version
+    testImplementation 'org.mockito:mockito-core:5.10.0' // Use a recent version
+    testImplementation "com.google.tsunami:tsunami-testing:${tsunamiVersion}"
+}
+
+protobuf {
+    protoc {
+        artifact = "com.google.protobuf:protoc:3.25.1" // Match protobuf-java version
+    }
+    plugins {
+        grpc {
+            artifact = "io.grpc:protoc-gen-grpc-java:1.60.0" // If you use gRPC, adjust version
+        }
+    }
+    generateProtoTasks {
+        all().each { task ->
+            // task.builtins {
+            //     java { option "lite" } // If using protobuf-javalite
+            // }
+            // if (task.name.contains("grpc")) {
+            //     task.plugins {
+            //         grpc { // Options added to --grpc_out
+            //         }
+            //     }
+            // }
+        }
+    }
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+}
+
+// Ensure the shadowJar task is configured to produce a fat JAR if needed for Tsunami plugins
+// This configuration might vary based on Tsunami's plugin loading mechanism
+shadowJar {
+    archiveClassifier.set('') // Produces a JAR without 'all' or 'shadow' in the name
+    // Configure as needed, e.g., to relocate dependencies to avoid conflicts
+    // relocate 'com.google.common', 'shadow.com.google.common'
+}
+
+// Make the shadowJar task the default build artifact
+artifacts {
+    archives shadowJar
+}
+
+// Often, Tsunami plugins might need a specific JAR manifest configuration
+jar {
+    manifest {
+        attributes(
+            // Example attributes, adjust as per Tsunami plugin requirements
+            // 'Main-Class': 'com.example.MainClass'
+        )
+    }
+}
+
+// Task to copy dependencies to a specific directory (optional, for reference)
+task copyDependencies(type: Copy) {
+    from configurations.runtimeClasspath
+    into 'build/libs/deps'
+}

--- a/plugins/mlflow_weak_credential_detector/src/main/java/com/google/tsunami/plugins/detectors/mlflow/MlflowWeakCredentialDetector.java
+++ b/plugins/mlflow_weak_credential_detector/src/main/java/com/google/tsunami/plugins/detectors/mlflow/MlflowWeakCredentialDetector.java
@@ -1,0 +1,157 @@
+package com.google.tsunami.plugins.detectors.mlflow;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.flogger.GoogleLogger;
+import com.google.protobuf.util.Timestamps;
+import com.google.tsunami.common.data.NetworkServiceUtils;
+import com.google.tsunami.common.net.http.HttpClient;
+import com.google.tsunami.common.net.http.HttpHeaders;
+import com.google.tsunami.common.net.http.HttpRequest;
+import com.google.tsunami.common.net.http.HttpResponse;
+import com.google.tsunami.common.time.UtcClock;
+import com.google.tsunami.plugin.PluginType;
+import com.google.tsunami.plugin.VulnDetector;
+import com.google.tsunami.plugin.annotations.PluginInfo;
+import com.google.tsunami.proto.DetectionReport;
+import com.google.tsunami.proto.DetectionReportList;
+import com.google.tsunami.proto.DetectionStatus;
+import com.google.tsunami.proto.NetworkService;
+import com.google.tsunami.proto.Severity;
+import com.google.tsunami.proto.TargetInfo;
+import com.google.tsunami.proto.Vulnerability;
+import com.google.tsunami.proto.VulnerabilityId;
+import java.io.IOException;
+import java.time.Clock;
+import java.time.Instant;
+import javax.inject.Inject;
+
+@PluginInfo(
+    type = PluginType.VULN_DETECTION,
+    name = "MlflowWeakCredentialDetector",
+    version = "0.1",
+    description = "Detects default weak credentials in MLflow instances.",
+    author = "Jules (AI Language Model)",
+    bootstrapModule = MlflowWeakCredentialDetectorBootstrapModule.class)
+public final class MlflowWeakCredentialDetector implements VulnDetector {
+  private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
+
+  private final Clock utcClock;
+  private final HttpClient httpClient;
+
+  // MLflow default credentials
+  private static final String DEFAULT_USERNAME = "admin";
+  private static final String DEFAULT_PASSWORD = "password";
+
+  // A simple MLflow API endpoint that requires authentication.
+  // We expect a 200 OK if creds are valid, 401/403 if invalid or auth not enabled in a certain way.
+  // This might need adjustment based on MLflow API specifics.
+  // Using `/api/2.0/mlflow/experiments/list` as an example.
+  private static final String MLFLOW_AUTH_TEST_PATH = "api/2.0/mlflow/experiments/list";
+
+
+  @Inject
+  MlflowWeakCredentialDetector(@UtcClock Clock utcClock, HttpClient httpClient) {
+    this.utcClock = checkNotNull(utcClock);
+    this.httpClient = checkNotNull(httpClient);
+  }
+
+  @Override
+  public DetectionReportList detect(
+      TargetInfo targetInfo, ImmutableList<NetworkService> matchedServices) {
+    logger.atInfo().log("MlflowWeakCredentialDetector starts scanning.");
+
+    return DetectionReportList.newBuilder()
+        .addAllDetectionReports(
+            matchedServices.stream()
+                .filter(NetworkServiceUtils::isWebService)
+                .filter(this::isMlflowService) // Add a check if this is actually an MLflow service if possible
+                .map(networkService -> checkServiceForWeakCredentials(targetInfo, networkService))
+                .filter(java.util.Optional::isPresent)
+                .map(java.util.Optional::get)
+                .collect(toImmutableList()))
+        .build();
+  }
+
+  private boolean isMlflowService(NetworkService networkService) {
+    // TODO: Implement a more reliable way to identify MLflow services.
+    // This could involve checking for specific path exposures, specific headers, or banner grabbing.
+    // For now, we assume any web service on common MLflow ports (e.g., 5000) might be MLflow.
+    // This is a simplification and should be improved.
+    if (networkService.getNetworkEndpoint().hasPort()) {
+        int port = networkService.getNetworkEndpoint().getPort().getPortNumber();
+        // Default MLflow port is 5000. Other common alternatives might be 80, 443 (if proxied)
+        return port == 5000 || port == 80 || port == 443;
+    }
+    return true; // If no port, proceed cautiously.
+  }
+
+  private java.util.Optional<DetectionReport> checkServiceForWeakCredentials(
+      TargetInfo targetInfo, NetworkService networkService) {
+    String targetUri = NetworkServiceUtils.buildWebApplicationUrl(networkService, MLFLOW_AUTH_TEST_PATH);
+    logger.atInfo().log("Testing URI for MLflow weak creds: %s", targetUri);
+
+    HttpRequest request = HttpRequest.get(targetUri)
+        .withCredentials(DEFAULT_USERNAME, DEFAULT_PASSWORD)
+        .build();
+
+    try {
+      HttpResponse response = httpClient.send(request, networkService);
+
+      // Successful authentication with default credentials
+      if (response.status().isSuccess()) {
+        // Check if the body indicates it's actually mlflow and not some other service that accepted the auth
+        // For now, we assume success means vulnerable.
+        logger.atInfo().log("Successfully authenticated to MLflow at %s with default credentials.", targetUri);
+        return java.util.Optional.of(buildDetectionReport(targetInfo, networkService, DEFAULT_USERNAME, DEFAULT_PASSWORD));
+      } else if (response.status().code() == 401 || response.status().code() == 403) {
+        // Unauthorized or Forbidden - This means auth is likely enabled, but these creds are wrong.
+        // This is the expected outcome if default creds are *not* used.
+        logger.atInfo().log("Authentication failed for %s with default credentials (status: %s), which is good.", targetUri, response.status());
+      } else {
+        // Other statuses might indicate auth is not enabled, or other issues.
+        // For MLflow, if basic auth is not configured, it might return pages directly or redirect.
+        // A more sophisticated check is needed here to differentiate "auth not enabled" from "service not MLflow".
+        // For now, we don't report these cases as a weak credential finding.
+        logger.atInfo().log("Unexpected status %s for %s. Auth might not be enabled or not an MLflow service.", response.status(), targetUri);
+      }
+    } catch (IOException e) {
+      logger.atWarning().withCause(e).log("Failed to send request to %s.", targetUri);
+    }
+    return java.util.Optional.empty();
+  }
+
+  private DetectionReport buildDetectionReport(
+      TargetInfo targetInfo, NetworkService vulnerableNetworkService, String username, String password) {
+    return DetectionReport.newBuilder()
+        .setTargetInfo(targetInfo)
+        .setNetworkService(vulnerableNetworkService)
+        .setDetectionTimestamp(Timestamps.fromMillis(Instant.now(utcClock).toEpochMilli()))
+        .setDetectionStatus(DetectionStatus.VULNERABILITY_VERIFIED)
+        .setVulnerability(
+            Vulnerability.newBuilder()
+                .setMainId(
+                    VulnerabilityId.newBuilder()
+                        .setPublisher("GOOGLE_JULES") // Using a distinct publisher
+                        .setValue("MLFLOW_WEAK_CREDENTIAL"))
+                .setSeverity(Severity.CRITICAL)
+                .setTitle("MLflow Default Weak Credentials")
+                .setDescription(
+                    String.format(
+                        "The MLflow instance at %s is using default weak credentials (username: '%s', password: '%s'). "
+                            + "This allows unauthorized access to experiments, models, and potentially the underlying infrastructure.",
+                        NetworkServiceUtils.buildWebApplicationUrl(vulnerableNetworkService),
+                        username,
+                        password))
+                .setRecommendation(
+                    "Change the default admin password immediately. "
+                        + "Refer to MLflow documentation for securely managing credentials. "
+                        + "If basic authentication is not required, consider disabling it or using a more robust authentication mechanism.")
+                // TODO: Add Cveid if one exists for this specific default credential issue.
+                .setCvssV3("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H") // Critical score for default admin creds
+                )
+        .build();
+  }
+}

--- a/plugins/mlflow_weak_credential_detector/src/main/java/com/google/tsunami/plugins/detectors/mlflow/MlflowWeakCredentialDetectorBootstrapModule.java
+++ b/plugins/mlflow_weak_credential_detector/src/main/java/com/google/tsunami/plugins/detectors/mlflow/MlflowWeakCredentialDetectorBootstrapModule.java
@@ -1,0 +1,13 @@
+package com.google.tsunami.plugins.detectors.mlflow;
+
+import com.google.tsunami.plugin.PluginBootstrapModule;
+
+public final class MlflowWeakCredentialDetectorBootstrapModule extends PluginBootstrapModule {
+
+  @Override
+  protected void configurePlugin() {
+    // Register the MlflowWeakCredentialDetector.
+    // Tsunami's plugin infrastructure will use this to instantiate and execute the detector.
+    registerPlugin(MlflowWeakCredentialDetector.class);
+  }
+}

--- a/plugins/mlflow_weak_credential_detector/src/test/java/com/google/tsunami/plugins/detectors/mlflow/MlflowWeakCredentialDetectorTest.java
+++ b/plugins/mlflow_weak_credential_detector/src/test/java/com/google/tsunami/plugins/detectors/mlflow/MlflowWeakCredentialDetectorTest.java
@@ -1,0 +1,247 @@
+package com.google.tsunami.plugins.detectors.mlflow;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.tsunami.common.data.NetworkEndpointUtils.forHostnameAndPort;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Guice;
+import com.google.tsunami.common.net.http.HttpClient;
+import com.google.tsunami.common.net.http.HttpRequest;
+import com.google.tsunami.common.net.http.HttpResponse;
+import com.google.tsunami.common.time.testing.FakeUtcClock;
+import com.google.tsunami.common.time.testing.FakeUtcClockModule;
+import com.google.tsunami.proto.DetectionReport;
+import com.google.tsunami.proto.DetectionReportList;
+import com.google.tsunami.proto.DetectionStatus;
+import com.google.tsunami.proto.NetworkService;
+import com.google.tsunami.proto.Severity;
+import com.google.tsunami.proto.TargetInfo;
+import com.google.tsunami.proto.TransportProtocol;
+import com.google.tsunami.proto.NetworkEndpoint;
+import java.io.IOException;
+import java.time.Instant;
+import javax.inject.Inject;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.AdditionalMatchers;
+
+@RunWith(JUnit4.class)
+public class MlflowWeakCredentialDetectorTest {
+
+  private FakeUtcClock fakeUtcClock;
+  private HttpClient mockHttpClient;
+
+  @Inject private MlflowWeakCredentialDetector detector;
+
+  private static final String DEFAULT_USERNAME = "admin";
+  private static final String DEFAULT_PASSWORD = "password";
+
+  @Before
+  public void setUp() {
+    fakeUtcClock = FakeUtcClock.create();
+    mockHttpClient = mock(HttpClient.class);
+
+    Guice.createInjector(
+            new FakeUtcClockModule(fakeUtcClock),
+            new MlflowWeakCredentialDetectorBootstrapModule(),
+            binder -> {
+              binder.bind(HttpClient.class).toInstance(mockHttpClient);
+            })
+        .injectMembers(this);
+  }
+
+  private TargetInfo buildTargetInfo(NetworkService networkService) {
+    return TargetInfo.newBuilder().addNetworkEndpoints(networkService.getNetworkEndpoint()).build();
+  }
+
+  private NetworkService buildNetworkService(int port, String softwareName, TransportProtocol transportProtocol) {
+    return NetworkService.newBuilder()
+        .setNetworkEndpoint(forHostnameAndPort("localhost", port))
+        .setTransportProtocol(transportProtocol)
+        .setServiceName("http") // Assume http for web services
+        .setSoftware(com.google.tsunami.proto.Software.newBuilder().setName(softwareName))
+        .build();
+  }
+   private NetworkService buildWebService(int port) {
+    return buildNetworkService(port, "mlflow", TransportProtocol.TCP);
+  }
+
+  private NetworkService buildNonWebService(int port) {
+     return NetworkService.newBuilder()
+        .setNetworkEndpoint(forHostnameAndPort("localhost", port))
+        .setTransportProtocol(TransportProtocol.TCP)
+        .setServiceName("ssh") // Example non-http service
+        .build();
+  }
+
+
+  @Test
+  public void detect_whenVulnerableMlflowService_returnsDetectionReport() throws IOException {
+    NetworkService mlflowService = buildWebService(5000);
+    TargetInfo targetInfo = buildTargetInfo(mlflowService);
+
+    HttpResponse mockHttpResponse = mock(HttpResponse.class);
+    when(mockHttpResponse.status()).thenReturn(com.google.tsunami.common.net.http.HttpStatus.OK);
+    // Mock response body if detector logic starts using it for verification
+    // when(mockHttpResponse.bodyBytes()).thenReturn(Optional.of("MLflow UI".getBytes(UTF_8)));
+
+    when(mockHttpClient.send(
+            AdditionalMatchers.and(
+                HttpRequest.get("http://localhost:5000/api/2.0/mlflow/experiments/list").build(),
+                HttpRequest.get("http://localhost:5000/api/2.0/mlflow/experiments/list")
+                    .withCredentials(DEFAULT_USERNAME, DEFAULT_PASSWORD)
+                    .build()),
+            any(NetworkService.class)))
+        .thenReturn(mockHttpResponse);
+
+    fakeUtcClock.setNow(Instant.parse("2020-01-01T00:00:00.00Z"));
+
+    DetectionReportList detectionReports =
+        detector.detect(targetInfo, ImmutableList.of(mlflowService));
+
+    assertThat(detectionReports.getDetectionReportsList()).hasSize(1);
+    DetectionReport report = detectionReports.getDetectionReports(0);
+    assertThat(report.getTargetInfo()).isEqualTo(targetInfo);
+    assertThat(report.getNetworkService()).isEqualTo(mlflowService);
+    assertThat(report.getDetectionStatus()).isEqualTo(DetectionStatus.VULNERABILITY_VERIFIED);
+    assertThat(report.getVulnerability().getMainId().getValue()).isEqualTo("MLFLOW_WEAK_CREDENTIAL");
+    assertThat(report.getVulnerability().getSeverity()).isEqualTo(Severity.CRITICAL);
+    assertThat(report.getVulnerability().getTitle()).isEqualTo("MLflow Default Weak Credentials");
+    assertThat(report.getVulnerability().getDescription())
+        .contains("username: 'admin', password: 'password'");
+    assertThat(report.getVulnerability().getCvssV3()).isEqualTo("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H");
+  }
+
+  @Test
+  public void detect_whenMlflowAuthEnabledButNotDefaultCreds_returnsNoReport() throws IOException {
+    NetworkService mlflowService = buildWebService(5000);
+    TargetInfo targetInfo = buildTargetInfo(mlflowService);
+
+    HttpResponse mockHttpResponse = mock(HttpResponse.class);
+    when(mockHttpResponse.status()).thenReturn(com.google.tsunami.common.net.http.HttpStatus.UNAUTHORIZED);
+
+    when(mockHttpClient.send(
+            any(HttpRequest.class), // More lenient matching for this case
+            any(NetworkService.class)))
+        .thenReturn(mockHttpResponse);
+
+    DetectionReportList detectionReports =
+        detector.detect(targetInfo, ImmutableList.of(mlflowService));
+
+    assertThat(detectionReports.getDetectionReportsList()).isEmpty();
+  }
+
+  @Test
+  public void detect_whenMlflowAuthNotEnabledOrNotMlflow_returnsNoReport() throws IOException {
+    // Simulate a service that returns 200 OK without any auth, or a non-MLflow service
+    NetworkService otherWebService = buildWebService(8080);
+    TargetInfo targetInfo = buildTargetInfo(otherWebService);
+
+    HttpResponse mockHttpResponse = mock(HttpResponse.class);
+    // For example, a 302 redirect, or a 200 OK that's not an MLflow authenticated page
+    // The current detector logic treats any non-200 (for default creds) and non-401/403 as "not vulnerable"
+    when(mockHttpResponse.status()).thenReturn(com.google.tsunami.common.net.http.HttpStatus.FOUND);
+
+    when(mockHttpClient.send(any(HttpRequest.class), any(NetworkService.class)))
+        .thenReturn(mockHttpResponse);
+
+    DetectionReportList detectionReports =
+        detector.detect(targetInfo, ImmutableList.of(otherWebService));
+
+    assertThat(detectionReports.getDetectionReportsList()).isEmpty();
+  }
+
+
+  @Test
+  public void detect_whenNonWebService_returnsNoReport() {
+    NetworkService nonWebService = buildNonWebService(22); // SSH service
+    TargetInfo targetInfo = buildTargetInfo(nonWebService);
+
+    DetectionReportList detectionReports =
+        detector.detect(targetInfo, ImmutableList.of(nonWebService));
+
+    assertThat(detectionReports.getDetectionReportsList()).isEmpty();
+  }
+
+
+  @Test
+  public void detect_whenHttpClientThrowsIOException_returnsNoReportAndLogs() throws IOException {
+    NetworkService mlflowService = buildWebService(5000);
+    TargetInfo targetInfo = buildTargetInfo(mlflowService);
+
+    when(mockHttpClient.send(any(HttpRequest.class), any(NetworkService.class)))
+        .thenThrow(new IOException("Simulated network error"));
+
+    DetectionReportList detectionReports =
+        detector.detect(targetInfo, ImmutableList.of(mlflowService));
+
+    assertThat(detectionReports.getDetectionReportsList()).isEmpty();
+    // Verification of logging would require a more complex setup (e.g., TestAppender for Logback/Flogger)
+  }
+
+  @Test
+  public void detect_whenIsMlflowServiceFalse_returnsNoReport() {
+    // Test the isMlflowService logic - current logic is port-based
+    NetworkService nonMlflowPortWebService = buildWebService(8001); // Not 5000, 80, or 443
+    TargetInfo targetInfo = buildTargetInfo(nonMlflowPortWebService);
+
+    DetectionReportList detectionReports =
+        detector.detect(targetInfo, ImmutableList.of(nonMlflowPortWebService));
+
+    assertThat(detectionReports.getDetectionReportsList()).isEmpty();
+  }
+
+  @Test
+  public void detect_whenIsMlflowServiceTrueForPort80_attemptsScan() throws IOException {
+    NetworkService mlflowServicePort80 = buildWebService(80);
+    TargetInfo targetInfo = buildTargetInfo(mlflowServicePort80);
+
+    HttpResponse mockHttpResponse = mock(HttpResponse.class);
+    when(mockHttpResponse.status()).thenReturn(com.google.tsunami.common.net.http.HttpStatus.OK);
+     when(mockHttpClient.send(
+            AdditionalMatchers.and(
+                HttpRequest.get("http://localhost:80/api/2.0/mlflow/experiments/list").build(),
+                HttpRequest.get("http://localhost:80/api/2.0/mlflow/experiments/list")
+                    .withCredentials(DEFAULT_USERNAME, DEFAULT_PASSWORD)
+                    .build()),
+            any(NetworkService.class)))
+        .thenReturn(mockHttpResponse);
+
+    DetectionReportList detectionReports =
+        detector.detect(targetInfo, ImmutableList.of(mlflowServicePort80));
+
+    assertThat(detectionReports.getDetectionReportsList()).hasSize(1); // Expecting a report
+  }
+
+   @Test
+  public void detect_whenIsMlflowServiceTrueForPort443_attemptsScan() throws IOException {
+    NetworkService mlflowServicePort443 = buildWebService(443);
+    // For HTTPS, NetworkServiceUtils.buildWebApplicationUrl should handle it
+    // We need to ensure our mock HttpClient is configured for this if it were a real HTTPS call
+    // but for mocking, the URL string is the main thing.
+    TargetInfo targetInfo = buildTargetInfo(mlflowServicePort443);
+
+
+    HttpResponse mockHttpResponse = mock(HttpResponse.class);
+    when(mockHttpResponse.status()).thenReturn(com.google.tsunami.common.net.http.HttpStatus.OK);
+     when(mockHttpClient.send(
+            AdditionalMatchers.and(
+                HttpRequest.get("https://localhost:443/api/2.0/mlflow/experiments/list").build(),
+                HttpRequest.get("https://localhost:443/api/2.0/mlflow/experiments/list")
+                    .withCredentials(DEFAULT_USERNAME, DEFAULT_PASSWORD)
+                    .build()),
+            any(NetworkService.class)))
+        .thenReturn(mockHttpResponse);
+
+
+    DetectionReportList detectionReports =
+        detector.detect(targetInfo, ImmutableList.of(mlflowServicePort443));
+
+    assertThat(detectionReports.getDetectionReportsList()).hasSize(1);
+  }
+}


### PR DESCRIPTION
This commit introduces a new Tsunami security scanner plugin to detect default weak credentials (admin:password) in MLflow instances.

The plugin includes:
- MlflowWeakCredentialDetector.java: The core detection logic that checks for weak credentials by attempting to authenticate against the MLflow API.
- MlflowWeakCredentialDetectorBootstrapModule.java: Registers the plugin with Tsunami.
- build.gradle: Gradle build script for the plugin.
- MlflowWeakCredentialDetectorTest.java: Unit tests for the detector, covering various scenarios.