### PR TITLE
Apache Pinot exposedUI Detector

### DIFF
--- a/templated/templateddetector/plugins/exposedui/ApachePinot_ExposedUI.textproto
+++ b/templated/templateddetector/plugins/exposedui/ApachePinot_ExposedUI.textproto
@@ -1,0 +1,68 @@
+# proto-file: proto/templated_plugin.proto
+# proto-message: TemplatedPlugin
+
+###############
+# PLUGIN INFO #
+###############
+
+info: {
+  type: VULN_DETECTION
+  name: "ApachePinot_ExposedUI"
+  author: "Alessandro Versari <alessandro.versari@doyensec.com>"
+  version: "1.0"
+}
+
+finding: {
+  main_id: {
+    publisher: "GOOGLE"
+    value: "ApachePinot_ExposedUI"
+  }
+  severity: HIGH
+  title: "Exposed Apache Pinot UI"
+  description: "Apache Pinot Dashboard is exposed to the internet without proper authentication, potentially allowing remote code execution. This vulnerability can lead to unauthorized access and control over the Apache Pinot cluster."
+  recommendation: "Don't Expose the ApachePinot Dashboard to the Internet. If you must expose it, ensure that proper authentication and authorization mechanisms are in place."
+}
+
+config: {}
+
+###########
+# ACTIONS #
+###########
+
+actions: {
+  name: "is_ApachePinot_dashboard"
+  http_request: {
+    method: GET
+    uri: "/"
+    response: {
+      http_status: 200
+      expect_all: {
+        conditions: [
+          { body: { } contains: "<meta name=\"description\" content=\"Pinot Controller UI\">" }
+        ]
+      }
+    }
+  }
+}
+
+actions: {
+  name: "read_tables"
+  http_request: {
+    method: GET
+    uri: "/tables"
+    response: {
+      http_status: 200
+    }
+  }
+}
+
+#############
+# WORKFLOWS #
+#############
+
+workflows: {
+  actions: [
+    "is_ApachePinot_dashboard",
+    "read_tables"
+  ]
+}

--- a/templated/templateddetector/plugins/exposedui/ApachePinot_ExposedUI_test.textproto
+++ b/templated/templateddetector/plugins/exposedui/ApachePinot_ExposedUI_test.textproto
@@ -1,0 +1,41 @@
+# proto-file: proto/templated_plugin_tests.proto
+# proto-message: TemplatedPluginTests
+
+config: {
+  tested_plugin: "ApachePinot_ExposedUI"
+}
+
+tests: {
+  name: "whenVulnerable_returnsTrue"
+  expect_vulnerability: true
+
+  mock_http_server: {
+    mock_responses: [
+      {
+        uri: "/"
+        status: 200
+        body_content: "<!DOCTYPE html><html><header><meta name=\"description\" content=\"Pinot Controller UI\"></header></html>"
+      },
+      {
+        uri: "/tables"
+        status: 200
+        body_content: "{\"tables\":[\"airlineStats\",\"baseballStats\"]"
+      }
+    ]
+  }
+}
+
+tests: {
+  name: "whenNotApachePinot_returnsFalse"
+  expect_vulnerability: false
+
+  mock_http_server: {
+    mock_responses: [
+      {
+        uri: "TSUNAMI_MAGIC_ANY_URI"
+        status: 200
+        body_content: "Hello world"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Detector for Apache Pinot exposedUI.

Testbed at https://github.com/google/security-testbeds/pull/183.

**Note:**

Apache Pinot UI does not inherently result in remote code execution (RCE). Therefore, this plugin determines if the Admin UI is exposed by validating the HTTP response returned from the `GET /tables` request.