### PR TITLE
Fix: Use correct tcsRepoBranch variable for TCS proto dependency

### DIFF
--- a/community/detectors/apache_apisix_cve_2022_24112/build.gradle
+++ b/community/detectors/apache_apisix_cve_2022_24112/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     }
 
     testImplementation("com.google.tsunami:tcs-proto") {
-      version { branch = "${coreRepoBranch}" }
+      version { branch = "${tcsRepoBranch}" }
     }
 
     testImplementation "junit:junit:4.13.2"

--- a/community/detectors/metabase_cve_2023_38646/build.gradle
+++ b/community/detectors/metabase_cve_2023_38646/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     }
 
     testImplementation("com.google.tsunami:tcs-proto") {
-      version { branch = "${coreRepoBranch}" }
+      version { branch = "${tcsRepoBranch}" }
     }
 
     testImplementation "junit:junit:4.13.2"

--- a/community/detectors/rce/apache_spark_exposed_api/build.gradle
+++ b/community/detectors/rce/apache_spark_exposed_api/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     annotationProcessor "com.google.auto.value:auto-value:1.11.0"
 
     testImplementation("com.google.tsunami:tcs-proto") {
-      version { branch = "${coreRepoBranch}" }
+      version { branch = "${tcsRepoBranch}" }
     }
 
     testImplementation "junit:junit:4.13.2"

--- a/community/detectors/rce/php_cve_2024_4577/build.gradle
+++ b/community/detectors/rce/php_cve_2024_4577/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     }
 
     testImplementation("com.google.tsunami:tcs-proto") {
-      version { branch = "${coreRepoBranch}" }
+      version { branch = "${tcsRepoBranch}" }
     }
 
     testImplementation "junit:junit:4.13.2"

--- a/community/detectors/zimbra_cve_2019_9670/build.gradle
+++ b/community/detectors/zimbra_cve_2019_9670/build.gradle
@@ -28,7 +28,7 @@ dependencies {
       version { branch = "${coreRepoBranch}" }
     }
     testImplementation("com.google.tsunami:tcs-proto") {
-      version { branch = "${coreRepoBranch}" }
+      version { branch = "${tcsRepoBranch}" }
     }
 
     testImplementation "junit:junit:4.13.2"

--- a/google/detectors/rce/confluence/cve202226134/build.gradle
+++ b/google/detectors/rce/confluence/cve202226134/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     }
 
     testImplementation("com.google.tsunami:tcs-proto") {
-      version { branch = "${coreRepoBranch}" }
+      version { branch = "${tcsRepoBranch}" }
     }
 
     testImplementation "junit:junit:4.13.2"

--- a/google/detectors/rce/cve20196340/build.gradle
+++ b/google/detectors/rce/cve20196340/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     }
 
     testImplementation("com.google.tsunami:tcs-proto") {
-      version { branch = "${coreRepoBranch}" }
+      version { branch = "${tcsRepoBranch}" }
     }
 
     testImplementation "junit:junit:4.13.2"

--- a/google/detectors/rce/cve202342793/build.gradle
+++ b/google/detectors/rce/cve202342793/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     }
 
     testImplementation("com.google.tsunami:tcs-proto") {
-      version { branch = "${coreRepoBranch}" }
+      version { branch = "${tcsRepoBranch}" }
     }
 
     testImplementation "junit:junit:4.13.2"

--- a/google/detectors/rce/weblogic/cve202014883/build.gradle
+++ b/google/detectors/rce/weblogic/cve202014883/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     }
 
     testImplementation("com.google.tsunami:tcs-proto") {
-      version { branch = "${coreRepoBranch}" }
+      version { branch = "${tcsRepoBranch}" }
     }
 
     testImplementation "junit:junit:4.13.2"


### PR DESCRIPTION
This fixes incorrect branch variable references for the tcs-proto test dependency across multiple plugin build files, which could cause build failures when using a custom Tsunami core.