### PR TITLE
Updated plugins to use TsunamiSocket

### DIFF
--- a/community/detectors/apache_activemq_cve_2023_46604/src/main/java/com/google/tsunami/plugins/detectors/cves/cve202346604/Cve202346604Detector.java
+++ b/community/detectors/apache_activemq_cve_2023_46604/src/main/java/com/google/tsunami/plugins/detectors/cves/cve202346604/Cve202346604Detector.java
@@ -25,6 +25,7 @@ import com.google.common.net.HostAndPort;
 import com.google.common.util.concurrent.Uninterruptibles;
 import com.google.protobuf.util.Timestamps;
 import com.google.tsunami.common.data.NetworkEndpointUtils;
+import com.google.tsunami.common.net.socket.TsunamiSocketFactory;
 import com.google.tsunami.common.time.UtcClock;
 import com.google.tsunami.plugin.PluginType;
 import com.google.tsunami.plugin.VulnDetector;
@@ -58,7 +59,6 @@ import java.time.Instant;
 import java.util.Map;
 import javax.inject.Inject;
 import javax.inject.Qualifier;
-import javax.net.SocketFactory;
 import org.apache.activemq.util.MarshallingSupport;
 
 /** A {@link VulnDetector} that detects the CVE-2023-46604 vulnerability. */
@@ -85,7 +85,7 @@ public final class Cve202346604Detector implements VulnDetector {
       ImmutableList.of("5.15.16", "5.16.7", "5.17.6", "5.18.3");
 
   private final Clock utcClock;
-  private final SocketFactory socketFactory;
+  private final TsunamiSocketFactory socketFactory;
   private final PayloadGenerator payloadGenerator;
   private final int oobSleepDuration;
 
@@ -96,7 +96,7 @@ public final class Cve202346604Detector implements VulnDetector {
   @Inject
   Cve202346604Detector(
       @UtcClock Clock utcClock,
-      @SocketFactoryInstance SocketFactory socketFactory,
+      TsunamiSocketFactory socketFactory,
       PayloadGenerator payloadGenerator,
       @OobSleepDuration int oobSleepDuration) {
     this.utcClock = checkNotNull(utcClock);

--- a/community/detectors/apache_activemq_cve_2023_46604/src/main/java/com/google/tsunami/plugins/detectors/cves/cve202346604/Cve202346604DetectorBootstrapModule.java
+++ b/community/detectors/apache_activemq_cve_2023_46604/src/main/java/com/google/tsunami/plugins/detectors/cves/cve202346604/Cve202346604DetectorBootstrapModule.java
@@ -15,23 +15,15 @@
  */
 package com.google.tsunami.plugins.detectors.cves.cve202346604;
 
-import com.google.inject.Key;
 import com.google.inject.Provides;
-import com.google.inject.multibindings.OptionalBinder;
 import com.google.tsunami.plugin.PluginBootstrapModule;
 import com.google.tsunami.plugins.detectors.cves.cve202346604.Annotations.OobSleepDuration;
-import javax.net.SocketFactory;
 
 /** An CVE-2023-46604 Guice module that bootstraps the {@link Cve202346604Detector}. */
 public final class Cve202346604DetectorBootstrapModule extends PluginBootstrapModule {
 
   @Override
   protected void configurePlugin() {
-    OptionalBinder.newOptionalBinder(
-            binder(),
-            Key.get(SocketFactory.class, Cve202346604Detector.SocketFactoryInstance.class))
-        .setDefault()
-        .toInstance(SocketFactory.getDefault());
     registerPlugin(Cve202346604Detector.class);
   }
 

--- a/community/detectors/apache_activemq_cve_2023_46604/src/test/java/com/google/tsunami/plugins/detectors/cves/cve202346604/Cve202346604DetectorTest.java
+++ b/community/detectors/apache_activemq_cve_2023_46604/src/test/java/com/google/tsunami/plugins/detectors/cves/cve202346604/Cve202346604DetectorTest.java
@@ -26,19 +26,17 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
-import com.google.inject.Key;
-import com.google.inject.multibindings.OptionalBinder;
 import com.google.inject.testing.fieldbinder.Bind;
 import com.google.inject.testing.fieldbinder.BoundFieldModule;
 import com.google.inject.util.Modules;
 import com.google.protobuf.util.Timestamps;
 import com.google.tsunami.common.net.http.HttpClientModule;
+import com.google.tsunami.common.net.socket.TsunamiSocketFactory;
 import com.google.tsunami.common.time.testing.FakeUtcClock;
 import com.google.tsunami.common.time.testing.FakeUtcClockModule;
 import com.google.tsunami.plugin.payload.testing.FakePayloadGeneratorModule;
 import com.google.tsunami.plugin.payload.testing.PayloadTestHelper;
 import com.google.tsunami.plugins.detectors.cves.cve202346604.Annotations.OobSleepDuration;
-import com.google.tsunami.plugins.detectors.cves.cve202346604.Cve202346604Detector.SocketFactoryInstance;
 import com.google.tsunami.proto.AdditionalDetail;
 import com.google.tsunami.proto.DetectionReport;
 import com.google.tsunami.proto.DetectionReportList;
@@ -60,7 +58,6 @@ import java.time.Instant;
 import java.util.Arrays;
 import java.util.Map;
 import javax.inject.Inject;
-import javax.net.SocketFactory;
 import okhttp3.mockwebserver.MockWebServer;
 import org.apache.activemq.util.MarshallingSupport;
 import org.junit.Before;
@@ -75,7 +72,7 @@ public final class Cve202346604DetectorTest {
   private final FakeUtcClock fakeUtcClock =
       FakeUtcClock.create().setNow(Instant.parse("2020-01-01T00:00:00.00Z"));
 
-  private final SocketFactory socketFactoryMock = mock(SocketFactory.class);
+  private final TsunamiSocketFactory socketFactoryMock = mock(TsunamiSocketFactory.class);
   private final SecureRandom testSecureRandom =
       new SecureRandom() {
         @Override
@@ -104,10 +101,7 @@ public final class Cve202346604DetectorTest {
             new AbstractModule() {
               @Override
               protected void configure() {
-                OptionalBinder.newOptionalBinder(
-                        binder(), Key.get(SocketFactory.class, SocketFactoryInstance.class))
-                    .setBinding()
-                    .toInstance(socketFactoryMock);
+                bind(TsunamiSocketFactory.class).toInstance(socketFactoryMock);
               }
             },
             Modules.override(new Cve202346604DetectorBootstrapModule())
@@ -128,10 +122,7 @@ public final class Cve202346604DetectorTest {
             new AbstractModule() {
               @Override
               protected void configure() {
-                OptionalBinder.newOptionalBinder(
-                        binder(), Key.get(SocketFactory.class, SocketFactoryInstance.class))
-                    .setBinding()
-                    .toInstance(socketFactoryMock);
+                bind(TsunamiSocketFactory.class).toInstance(socketFactoryMock);
               }
             },
             new HttpClientModule.Builder().build())

--- a/community/detectors/atlassian_bitbucket_dc_cve_2022_26133/src/main/java/com/google/tsunami/plugins/detectors/rce/cve202226133/Cve202226133Detector.java
+++ b/community/detectors/atlassian_bitbucket_dc_cve_2022_26133/src/main/java/com/google/tsunami/plugins/detectors/rce/cve202226133/Cve202226133Detector.java
@@ -29,6 +29,7 @@ import com.google.common.util.concurrent.Uninterruptibles;
 import com.google.protobuf.util.Timestamps;
 import com.google.tsunami.common.data.NetworkEndpointUtils;
 import com.google.tsunami.common.data.NetworkServiceUtils;
+import com.google.tsunami.common.net.socket.TsunamiSocketFactory;
 import com.google.tsunami.common.time.UtcClock;
 import com.google.tsunami.plugin.PluginType;
 import com.google.tsunami.plugin.VulnDetector;
@@ -69,7 +70,7 @@ public final class Cve202226133Detector implements VulnDetector {
   private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
   private final Clock utcClock;
   private final PayloadGenerator payloadGenerator;
-  private final SocketFactory socketFactory;
+  private final TsunamiSocketFactory socketFactory;
   private static final byte[] CLUSTER_NAME_REQUEST_GARBAGE =
       new byte[] {0x00, 0x00, 0x00, 0x02, 0x73, 0x61};
   private static final String RCE_CMD_PLACEHOLDER = "{{CMD}}";
@@ -81,7 +82,7 @@ public final class Cve202226133Detector implements VulnDetector {
   @Inject
   Cve202226133Detector(
       @UtcClock Clock utcClock,
-      @SocketFactoryInstance SocketFactory socketFactory,
+      TsunamiSocketFactory socketFactory,
       PayloadGenerator payloadGenerator) {
     this.utcClock = checkNotNull(utcClock);
     this.socketFactory = checkNotNull(socketFactory);

--- a/community/detectors/atlassian_bitbucket_dc_cve_2022_26133/src/main/java/com/google/tsunami/plugins/detectors/rce/cve202226133/Cve202226133DetectorBootstrapModule.java
+++ b/community/detectors/atlassian_bitbucket_dc_cve_2022_26133/src/main/java/com/google/tsunami/plugins/detectors/rce/cve202226133/Cve202226133DetectorBootstrapModule.java
@@ -15,21 +15,13 @@
  */
 package com.google.tsunami.plugins.detectors.rce.cve202226133;
 
-import com.google.inject.Key;
-import com.google.inject.multibindings.OptionalBinder;
 import com.google.tsunami.plugin.PluginBootstrapModule;
-import com.google.tsunami.plugins.detectors.rce.cve202226133.Cve202226133Detector.SocketFactoryInstance;
-import javax.net.SocketFactory;
 
 /** A {@link PluginBootstrapModule} for {@link Cve202226133Detector}. */
 public final class Cve202226133DetectorBootstrapModule extends PluginBootstrapModule {
 
   @Override
   protected void configurePlugin() {
-    OptionalBinder.newOptionalBinder(
-            binder(), Key.get(SocketFactory.class, SocketFactoryInstance.class))
-        .setDefault()
-        .toInstance(SocketFactory.getDefault());
     registerPlugin(Cve202226133Detector.class);
   }
 }

--- a/community/detectors/atlassian_bitbucket_dc_cve_2022_26133/src/test/java/com/google/tsunami/plugins/detectors/rce/cve202226133/Cve202226133DetectorWithCallbackServerTest.java
+++ b/community/detectors/atlassian_bitbucket_dc_cve_2022_26133/src/test/java/com/google/tsunami/plugins/detectors/rce/cve202226133/Cve202226133DetectorWithCallbackServerTest.java
@@ -24,14 +24,12 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
-import com.google.inject.Key;
-import com.google.inject.multibindings.OptionalBinder;
 import com.google.tsunami.common.net.http.HttpClientModule;
+import com.google.tsunami.common.net.socket.TsunamiSocketFactory;
 import com.google.tsunami.common.time.testing.FakeUtcClock;
 import com.google.tsunami.common.time.testing.FakeUtcClockModule;
 import com.google.tsunami.plugin.payload.testing.FakePayloadGeneratorModule;
 import com.google.tsunami.plugin.payload.testing.PayloadTestHelper;
-import com.google.tsunami.plugins.detectors.rce.cve202226133.Cve202226133Detector.SocketFactoryInstance;
 import com.google.tsunami.proto.DetectionReportList;
 import com.google.tsunami.proto.NetworkService;
 import com.google.tsunami.proto.TargetInfo;
@@ -41,7 +39,6 @@ import java.io.IOException;
 import java.net.Socket;
 import java.time.Instant;
 import javax.inject.Inject;
-import javax.net.SocketFactory;
 import okhttp3.mockwebserver.MockWebServer;
 import org.junit.After;
 import org.junit.Before;
@@ -54,7 +51,7 @@ import org.junit.runners.JUnit4;
 public final class Cve202226133DetectorWithCallbackServerTest {
   private final FakeUtcClock fakeUtcClock =
       FakeUtcClock.create().setNow(Instant.parse("2022-10-20T00:00:00.00Z"));
-  private final SocketFactory socketFactoryMock = mock(SocketFactory.class);
+  private final TsunamiSocketFactory socketFactoryMock = mock(TsunamiSocketFactory.class);
   private MockWebServer mockCallbackServer;
   @Inject private Cve202226133Detector detector;
   private TargetInfo targetInfo;
@@ -70,10 +67,7 @@ public final class Cve202226133DetectorWithCallbackServerTest {
             new AbstractModule() {
               @Override
               protected void configure() {
-                OptionalBinder.newOptionalBinder(
-                        binder(), Key.get(SocketFactory.class, SocketFactoryInstance.class))
-                    .setBinding()
-                    .toInstance(socketFactoryMock);
+                bind(TsunamiSocketFactory.class).toInstance(socketFactoryMock);
               }
             },
             new HttpClientModule.Builder().build(),

--- a/community/detectors/atlassian_bitbucket_dc_cve_2022_26133/src/test/java/com/google/tsunami/plugins/detectors/rce/cve202226133/Cve202226133DetectorWithoutCallbackServerTest.java
+++ b/community/detectors/atlassian_bitbucket_dc_cve_2022_26133/src/test/java/com/google/tsunami/plugins/detectors/rce/cve202226133/Cve202226133DetectorWithoutCallbackServerTest.java
@@ -24,13 +24,11 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
-import com.google.inject.Key;
-import com.google.inject.multibindings.OptionalBinder;
 import com.google.tsunami.common.net.http.HttpClientModule;
+import com.google.tsunami.common.net.socket.TsunamiSocketFactory;
 import com.google.tsunami.common.time.testing.FakeUtcClock;
 import com.google.tsunami.common.time.testing.FakeUtcClockModule;
 import com.google.tsunami.plugin.payload.testing.FakePayloadGeneratorModule;
-import com.google.tsunami.plugins.detectors.rce.cve202226133.Cve202226133Detector.SocketFactoryInstance;
 import com.google.tsunami.proto.DetectionReportList;
 import com.google.tsunami.proto.NetworkService;
 import com.google.tsunami.proto.TargetInfo;
@@ -40,7 +38,6 @@ import java.io.IOException;
 import java.net.Socket;
 import java.time.Instant;
 import javax.inject.Inject;
-import javax.net.SocketFactory;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -52,7 +49,7 @@ import org.mockito.stubbing.Answer;
 public final class Cve202226133DetectorWithoutCallbackServerTest {
   private final FakeUtcClock fakeUtcClock =
       FakeUtcClock.create().setNow(Instant.parse("2022-10-20T00:00:00.00Z"));
-  private final SocketFactory socketFactoryMock = mock(SocketFactory.class);
+  private final TsunamiSocketFactory socketFactoryMock = mock(TsunamiSocketFactory.class);
   @Inject private Cve202226133Detector detector;
   private TargetInfo targetInfo;
   private NetworkService service;
@@ -64,10 +61,7 @@ public final class Cve202226133DetectorWithoutCallbackServerTest {
             new AbstractModule() {
               @Override
               protected void configure() {
-                OptionalBinder.newOptionalBinder(
-                        binder(), Key.get(SocketFactory.class, SocketFactoryInstance.class))
-                    .setBinding()
-                    .toInstance(socketFactoryMock);
+                bind(TsunamiSocketFactory.class).toInstance(socketFactoryMock);
               }
             },
             new HttpClientModule.Builder().build(),

--- a/community/detectors/erlangotp_cve_2025_32433/src/main/java/com/google/tsunami/plugins/detectors/rce/cve202532433/Annotations.java
+++ b/community/detectors/erlangotp_cve_2025_32433/src/main/java/com/google/tsunami/plugins/detectors/rce/cve202532433/Annotations.java
@@ -32,10 +32,5 @@ final class Annotations {
   @Target({PARAMETER, METHOD, FIELD})
   @interface OobSleepDuration {}
 
-  @Qualifier
-  @Retention(RetentionPolicy.RUNTIME)
-  @Target({PARAMETER, METHOD, FIELD})
-  @interface SocketFactoryInstance {}
-
   private Annotations() {}
 }

--- a/community/detectors/erlangotp_cve_2025_32433/src/main/java/com/google/tsunami/plugins/detectors/rce/cve202532433/ErlangOtpSshCve2025324336Detector.java
+++ b/community/detectors/erlangotp_cve_2025_32433/src/main/java/com/google/tsunami/plugins/detectors/rce/cve202532433/ErlangOtpSshCve2025324336Detector.java
@@ -24,6 +24,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.flogger.GoogleLogger;
 import com.google.common.util.concurrent.Uninterruptibles;
 import com.google.protobuf.util.Timestamps;
+import com.google.tsunami.common.net.socket.TsunamiSocketFactory;
 import com.google.tsunami.common.time.UtcClock;
 import com.google.tsunami.plugin.PluginType;
 import com.google.tsunami.plugin.VulnDetector;
@@ -32,7 +33,6 @@ import com.google.tsunami.plugin.payload.NotImplementedException;
 import com.google.tsunami.plugin.payload.Payload;
 import com.google.tsunami.plugin.payload.PayloadGenerator;
 import com.google.tsunami.plugins.detectors.rce.cve202532433.Annotations.OobSleepDuration;
-import com.google.tsunami.plugins.detectors.rce.cve202532433.Annotations.SocketFactoryInstance;
 import com.google.tsunami.proto.DetectionReport;
 import com.google.tsunami.proto.DetectionReportList;
 import com.google.tsunami.proto.DetectionStatus;
@@ -50,7 +50,6 @@ import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import javax.inject.Inject;
-import javax.net.SocketFactory;
 
 /** A Tsunami plugin that detects Erlang/OTP SSH RCE vulnerability CVE-2025-32433. */
 @PluginInfo(
@@ -65,14 +64,14 @@ public class ErlangOtpSshCve2025324336Detector implements VulnDetector {
 
   private final Clock utcClock;
   private final PayloadGenerator payloadGenerator;
-  private final SocketFactory socketFactory;
+  private final TsunamiSocketFactory socketFactory;
   private final int oobSleepDuration;
 
   @Inject
   ErlangOtpSshCve2025324336Detector(
       @UtcClock Clock utcClock,
       PayloadGenerator payloadGenerator,
-      @SocketFactoryInstance SocketFactory socketFactory,
+      TsunamiSocketFactory socketFactory,
       @OobSleepDuration int oobSleepDuration) {
     this.utcClock = checkNotNull(utcClock);
     this.payloadGenerator = checkNotNull(payloadGenerator);
@@ -130,7 +129,6 @@ public class ErlangOtpSshCve2025324336Detector implements VulnDetector {
     var servicePort = service.getNetworkEndpoint().getPort().getPortNumber();
     try (var socket = socketFactory.createSocket(serviceIp, servicePort)) {
       // Connecting to SSH server...
-      socket.setSoTimeout(5000);
       OutputStream out = socket.getOutputStream();
       InputStream in = socket.getInputStream();
       // Banner exchange

--- a/community/detectors/erlangotp_cve_2025_32433/src/main/java/com/google/tsunami/plugins/detectors/rce/cve202532433/ErlangOtpSshCve2025324336DetectorBootstrapModule.java
+++ b/community/detectors/erlangotp_cve_2025_32433/src/main/java/com/google/tsunami/plugins/detectors/rce/cve202532433/ErlangOtpSshCve2025324336DetectorBootstrapModule.java
@@ -19,8 +19,6 @@ package com.google.tsunami.plugins.detectors.rce.cve202532433;
 import com.google.inject.Provides;
 import com.google.tsunami.plugin.PluginBootstrapModule;
 import com.google.tsunami.plugins.detectors.rce.cve202532433.Annotations.OobSleepDuration;
-import com.google.tsunami.plugins.detectors.rce.cve202532433.Annotations.SocketFactoryInstance;
-import javax.net.SocketFactory;
 
 /** A module for bootstrapping the {@link ErlangOtpSshCve2025324336Detector}. */
 public final class ErlangOtpSshCve2025324336DetectorBootstrapModule extends PluginBootstrapModule {
@@ -37,11 +35,5 @@ public final class ErlangOtpSshCve2025324336DetectorBootstrapModule extends Plug
       return 2;
     }
     return configs.oobSleepDuration;
-  }
-
-  @Provides
-  @SocketFactoryInstance
-  SocketFactory provideSocketFactoryInstance() {
-    return SocketFactory.getDefault();
   }
 }

--- a/community/detectors/redis_cve_2022_0543/src/main/java/com/google/tsunami/plugins/detectors/cves/Cve20220543DetectorBootstrapModule.java
+++ b/community/detectors/redis_cve_2022_0543/src/main/java/com/google/tsunami/plugins/detectors/cves/Cve20220543DetectorBootstrapModule.java
@@ -15,19 +15,13 @@
  */
 package com.google.tsunami.plugins.detectors.cves;
 
-import com.google.inject.multibindings.OptionalBinder;
 import com.google.tsunami.plugin.PluginBootstrapModule;
-import javax.net.SocketFactory;
 
 /** A Guice module that bootstraps the {@link Cve20220543Detector}. */
 public final class Cve20220543DetectorBootstrapModule extends PluginBootstrapModule {
 
   @Override
   protected void configurePlugin() {
-    OptionalBinder.newOptionalBinder(binder(), SocketFactory.class)
-        .setDefault()
-        .toInstance(SocketFactory.getDefault());
-
     registerPlugin(Cve20220543Detector.class);
   }
 }

--- a/community/detectors/redis_cve_2022_0543/src/test/java/com/google/tsunami/plugins/detectors/cves/Cve20220543DetectorTest.java
+++ b/community/detectors/redis_cve_2022_0543/src/test/java/com/google/tsunami/plugins/detectors/cves/Cve20220543DetectorTest.java
@@ -18,15 +18,17 @@ package com.google.tsunami.plugins.detectors.cves;
 import static com.google.common.truth.extensions.proto.ProtoTruth.assertThat;
 import static com.google.tsunami.common.data.NetworkEndpointUtils.forIpAndPort;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
-import com.google.inject.multibindings.OptionalBinder;
 import com.google.protobuf.util.Timestamps;
 import com.google.tsunami.common.net.http.HttpClientModule;
+import com.google.tsunami.common.net.socket.TsunamiSocketFactory;
 import com.google.tsunami.common.time.testing.FakeUtcClock;
 import com.google.tsunami.common.time.testing.FakeUtcClockModule;
 import com.google.tsunami.plugin.payload.testing.FakePayloadGeneratorModule;
@@ -43,7 +45,6 @@ import java.security.SecureRandom;
 import java.time.Instant;
 import java.util.Arrays;
 import javax.inject.Inject;
-import javax.net.SocketFactory;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -60,7 +61,7 @@ public final class Cve20220543DetectorTest {
 
   @Inject private Cve20220543Detector detector;
 
-  private final SocketFactory socketFactoryMock = mock(SocketFactory.class);
+  private final TsunamiSocketFactory socketFactoryMock = mock(TsunamiSocketFactory.class);
   private final SecureRandom testSecureRandom =
       new SecureRandom() {
         @Override
@@ -79,9 +80,7 @@ public final class Cve20220543DetectorTest {
             new AbstractModule() {
               @Override
               protected void configure() {
-                OptionalBinder.newOptionalBinder(binder(), SocketFactory.class)
-                    .setBinding()
-                    .toInstance(socketFactoryMock);
+                bind(TsunamiSocketFactory.class).toInstance(socketFactoryMock);
               }
             })
         .injectMembers(this);
@@ -90,7 +89,7 @@ public final class Cve20220543DetectorTest {
   private void getMock(String output) throws IOException {
     Socket socket = mock(Socket.class);
 
-    when(socketFactoryMock.createSocket()).thenReturn(socket);
+    when(socketFactoryMock.createSocket(anyString(), anyInt())).thenReturn(socket);
     when(socket.getOutputStream()).thenReturn(new ByteArrayOutputStream());
     when(socket.getInputStream()).thenReturn(new ByteArrayInputStream(output.getBytes(UTF_8)));
     when(socket.isConnected()).thenReturn(true);

--- a/doyensec/detectors/rocketmq_rce_cve_2023_33246/src/main/java/com/google/tsunami/plugins/detectors/rce/cve202333246/RocketMqCve202333246Detector.java
+++ b/doyensec/detectors/rocketmq_rce_cve_2023_33246/src/main/java/com/google/tsunami/plugins/detectors/rce/cve202333246/RocketMqCve202333246Detector.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.flogger.GoogleLogger;
 import com.google.common.util.concurrent.Uninterruptibles;
 import com.google.protobuf.util.Timestamps;
+import com.google.tsunami.common.net.socket.TsunamiSocketFactory;
 import com.google.tsunami.common.time.UtcClock;
 import com.google.tsunami.plugin.PluginType;
 import com.google.tsunami.plugin.VulnDetector;
@@ -29,7 +30,6 @@ import com.google.tsunami.plugin.annotations.PluginInfo;
 import com.google.tsunami.plugin.payload.Payload;
 import com.google.tsunami.plugin.payload.PayloadGenerator;
 import com.google.tsunami.plugins.detectors.rce.cve202333246.Annotations.OobSleepDuration;
-import com.google.tsunami.plugins.detectors.rce.cve202333246.Annotations.SocketFactoryInstance;
 import com.google.tsunami.proto.DetectionReport;
 import com.google.tsunami.proto.DetectionReportList;
 import com.google.tsunami.proto.DetectionStatus;
@@ -64,14 +64,14 @@ public final class RocketMqCve202333246Detector implements VulnDetector {
       "{\"code\":%d,\"flag\":0,\"language\":\"JAVA\",\"opaque\":0,\"serializeTypeCurrentRPC\":\"JSON\",\"version\":395}";
   private final Clock utcClock;
   private final PayloadGenerator payloadGenerator;
-  private final SocketFactory socketFactory;
+  private final TsunamiSocketFactory socketFactory;
   private final int oobSleepDuration;
 
   @Inject
   RocketMqCve202333246Detector(
       @UtcClock Clock utcClock,
       PayloadGenerator payloadGenerator,
-      @SocketFactoryInstance SocketFactory socketFactory,
+      TsunamiSocketFactory socketFactory,
       @OobSleepDuration int oobSleepDuration) {
     this.utcClock = checkNotNull(utcClock);
     this.payloadGenerator = checkNotNull(payloadGenerator);
@@ -152,7 +152,6 @@ public final class RocketMqCve202333246Detector implements VulnDetector {
     var servicePort = service.getNetworkEndpoint().getPort().getPortNumber();
 
     try (var socket = socketFactory.createSocket(serviceIp, servicePort)) {
-      socket.setSoTimeout(2000);
       socket.getOutputStream().write(payload);
 
       byte[] response = new byte[4096];

--- a/doyensec/detectors/rocketmq_rce_cve_2023_33246/src/main/java/com/google/tsunami/plugins/detectors/rce/cve202333246/RocketMqCve202333246DetectorBootstrapModule.java
+++ b/doyensec/detectors/rocketmq_rce_cve_2023_33246/src/main/java/com/google/tsunami/plugins/detectors/rce/cve202333246/RocketMqCve202333246DetectorBootstrapModule.java
@@ -18,8 +18,6 @@ package com.google.tsunami.plugins.detectors.rce.cve202333246;
 import com.google.inject.Provides;
 import com.google.tsunami.plugin.PluginBootstrapModule;
 import com.google.tsunami.plugins.detectors.rce.cve202333246.Annotations.OobSleepDuration;
-import com.google.tsunami.plugins.detectors.rce.cve202333246.Annotations.SocketFactoryInstance;
-import javax.net.SocketFactory;
 
 /** A module for bootstrapping the {@link RocketMqCve202333246Detector}. */
 public final class RocketMqCve202333246DetectorBootstrapModule extends PluginBootstrapModule {
@@ -36,11 +34,5 @@ public final class RocketMqCve202333246DetectorBootstrapModule extends PluginBoo
       return 40;
     }
     return configs.oobSleepDuration;
-  }
-
-  @Provides
-  @SocketFactoryInstance
-  SocketFactory provideSocketFactoryInstance() {
-    return SocketFactory.getDefault();
   }
 }

--- a/doyensec/detectors/rocketmq_rce_cve_2023_33246/src/test/java/com/google/tsunami/plugins/detectors/rce/cve202333246/RocketMqCve202333246DetectorTest.java
+++ b/doyensec/detectors/rocketmq_rce_cve_2023_33246/src/test/java/com/google/tsunami/plugins/detectors/rce/cve202333246/RocketMqCve202333246DetectorTest.java
@@ -26,12 +26,12 @@ import com.google.inject.util.Modules;
 import com.google.protobuf.util.Timestamps;
 import com.google.tsunami.common.data.NetworkEndpointUtils;
 import com.google.tsunami.common.net.http.HttpClientModule;
+import com.google.tsunami.common.net.socket.TsunamiSocketFactory;
 import com.google.tsunami.common.time.testing.FakeUtcClock;
 import com.google.tsunami.common.time.testing.FakeUtcClockModule;
 import com.google.tsunami.plugin.payload.testing.FakePayloadGeneratorModule;
 import com.google.tsunami.plugin.payload.testing.PayloadTestHelper;
 import com.google.tsunami.plugins.detectors.rce.cve202333246.Annotations.OobSleepDuration;
-import com.google.tsunami.plugins.detectors.rce.cve202333246.Annotations.SocketFactoryInstance;
 import com.google.tsunami.proto.DetectionReport;
 import com.google.tsunami.proto.DetectionReportList;
 import com.google.tsunami.proto.DetectionStatus;
@@ -46,7 +46,6 @@ import java.net.Socket;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import javax.inject.Inject;
-import javax.net.SocketFactory;
 import okhttp3.mockwebserver.MockWebServer;
 import org.junit.After;
 import org.junit.Before;
@@ -75,8 +74,7 @@ public class RocketMqCve202333246DetectorTest {
   private final int sleepDuration = 1;
 
   @Bind(lazy = true)
-  @SocketFactoryInstance
-  private final SocketFactory socketFactoryMock = Mockito.mock(SocketFactory.class);
+  private final TsunamiSocketFactory socketFactoryMock = Mockito.mock(TsunamiSocketFactory.class);
 
   @Before
   public void setUp() throws IOException {

--- a/facebook/detectors/rce/cisco_smi/src/main/java/com/google/tsunami/plugins/detectors/rce/cisco_smi/CiscoSMIDetector.java
+++ b/facebook/detectors/rce/cisco_smi/src/main/java/com/google/tsunami/plugins/detectors/rce/cisco_smi/CiscoSMIDetector.java
@@ -35,13 +35,13 @@ import com.google.tsunami.proto.NetworkService;
 import com.google.tsunami.proto.Severity;
 import com.google.tsunami.proto.TargetInfo;
 import com.google.tsunami.proto.Vulnerability;
+import com.google.tsunami.common.net.socket.TsunamiSocketFactory;
 import com.google.tsunami.proto.VulnerabilityId;
 import java.net.Socket;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.Arrays;
 import javax.inject.Inject;
-import javax.net.SocketFactory;
 
 /** A {@link VulnDetector} that detects vulnerable Cisco Smart Install protocol */
 @ForServiceName({"smart-install"})
@@ -56,10 +56,10 @@ public final class CiscoSMIDetector implements VulnDetector {
   private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
 
   private final Clock utcClock;
-  private final SocketFactory socketFactory;
+  private final TsunamiSocketFactory socketFactory;
 
   @Inject
-  public CiscoSMIDetector(@UtcClock Clock utcClock, SocketFactory socketFactory) {
+  public CiscoSMIDetector(@UtcClock Clock utcClock, TsunamiSocketFactory socketFactory) {
     this.utcClock = checkNotNull(utcClock);
     this.socketFactory = checkNotNull(socketFactory);
   }
@@ -109,7 +109,6 @@ public final class CiscoSMIDetector implements VulnDetector {
 
     try {
       Socket socket = socketFactory.createSocket(hp.getHost(), hp.getPort());
-      socket.setSoTimeout(2000);
       socket.getOutputStream().write(request);
       socket.getInputStream().read(actualResponse, 0, actualResponse.length);
       socket.close();

--- a/facebook/detectors/rce/cisco_smi/src/main/java/com/google/tsunami/plugins/detectors/rce/cisco_smi/CiscoSMIDetectorBootstrapModule.java
+++ b/facebook/detectors/rce/cisco_smi/src/main/java/com/google/tsunami/plugins/detectors/rce/cisco_smi/CiscoSMIDetectorBootstrapModule.java
@@ -15,18 +15,13 @@
  */
 package com.google.tsunami.plugins.detectors.rce.ciscosmi;
 
-import com.google.inject.multibindings.OptionalBinder;
 import com.google.tsunami.plugin.PluginBootstrapModule;
-import javax.net.SocketFactory;
 
 /** A {@link PluginBootstrapModule} for {@link CiscoSMIDetector}. */
 public final class CiscoSMIDetectorBootstrapModule extends PluginBootstrapModule {
 
   @Override
   protected void configurePlugin() {
-    OptionalBinder.newOptionalBinder(binder(), SocketFactory.class)
-        .setDefault()
-        .toInstance(SocketFactory.getDefault());
     registerPlugin(CiscoSMIDetector.class);
   }
 }

--- a/facebook/detectors/rce/cisco_smi/src/test/java/com/google/tsunami/plugins/detectors/rce/cisco_smi/CiscoSMIDetectorTest.java
+++ b/facebook/detectors/rce/cisco_smi/src/test/java/com/google/tsunami/plugins/detectors/rce/cisco_smi/CiscoSMIDetectorTest.java
@@ -27,8 +27,8 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
-import com.google.inject.multibindings.OptionalBinder;
 import com.google.protobuf.util.Timestamps;
+import com.google.tsunami.common.net.socket.TsunamiSocketFactory;
 import com.google.tsunami.common.time.testing.FakeUtcClock;
 import com.google.tsunami.common.time.testing.FakeUtcClockModule;
 import com.google.tsunami.proto.DetectionReport;
@@ -41,7 +41,6 @@ import java.io.ByteArrayOutputStream;
 import java.net.Socket;
 import java.time.Instant;
 import javax.inject.Inject;
-import javax.net.SocketFactory;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -51,7 +50,7 @@ public final class CiscoSMIDetectorTest {
   private final FakeUtcClock fakeUtcClock =
       FakeUtcClock.create().setNow(Instant.parse("2021-01-01T00:00:00.00Z"));
 
-  private final SocketFactory socketFactoryMock = mock(SocketFactory.class);
+  private final TsunamiSocketFactory socketFactoryMock = mock(TsunamiSocketFactory.class);
 
   @Inject private CiscoSMIDetector detector;
 
@@ -62,9 +61,7 @@ public final class CiscoSMIDetectorTest {
             new AbstractModule() {
               @Override
               protected void configure() {
-                OptionalBinder.newOptionalBinder(binder(), SocketFactory.class)
-                    .setBinding()
-                    .toInstance(socketFactoryMock);
+                bind(TsunamiSocketFactory.class).toInstance(socketFactoryMock);
               }
             },
             new CiscoSMIDetectorBootstrapModule())

--- a/google/detectors/rce/redis/src/main/java/com/google/tsunami/plugins/detectors/rce/redis/RedisUnauthenticatedCommandExecutionDetector.java
+++ b/google/detectors/rce/redis/src/main/java/com/google/tsunami/plugins/detectors/rce/redis/RedisUnauthenticatedCommandExecutionDetector.java
@@ -24,6 +24,7 @@ import com.google.common.flogger.GoogleLogger;
 import com.google.common.net.HostAndPort;
 import com.google.protobuf.util.Timestamps;
 import com.google.tsunami.common.data.NetworkEndpointUtils;
+import com.google.tsunami.common.net.socket.TsunamiSocketFactory;
 import com.google.tsunami.common.time.UtcClock;
 import com.google.tsunami.plugin.PluginType;
 import com.google.tsunami.plugin.VulnDetector;
@@ -44,7 +45,6 @@ import java.net.Socket;
 import java.time.Clock;
 import java.time.Instant;
 import javax.inject.Inject;
-import javax.net.SocketFactory;
 
 /** Detects Redis unauthenticated command execution allowing RCE. */
 @PluginInfo(
@@ -85,11 +85,11 @@ public final class RedisUnauthenticatedCommandExecutionDetector implements VulnD
           + "Then restart Redis service for the settings to take effect.";
 
   private final Clock utcClock;
-  private final SocketFactory socketFactory;
+  private final TsunamiSocketFactory socketFactory;
 
   @Inject
   RedisUnauthenticatedCommandExecutionDetector(
-      @UtcClock Clock utcClock, @SocketFactoryInstance SocketFactory socketFactory) {
+      @UtcClock Clock utcClock, TsunamiSocketFactory socketFactory) {
     this.utcClock = checkNotNull(utcClock);
     this.socketFactory = checkNotNull(socketFactory);
   }
@@ -142,7 +142,6 @@ public final class RedisUnauthenticatedCommandExecutionDetector implements VulnD
     HostAndPort hp = NetworkEndpointUtils.toHostAndPort(networkService.getNetworkEndpoint());
 
     try (Socket socket = socketFactory.createSocket(hp.getHost(), hp.getPort())) {
-      socket.setSoTimeout(2000);
       socket.getOutputStream().write("INFO server\r\n".getBytes(UTF_8));
       byte[] responseBuffer = new byte[100];
       int bytesRead = socket.getInputStream().read(responseBuffer, 0, responseBuffer.length);

--- a/google/detectors/rce/redis/src/main/java/com/google/tsunami/plugins/detectors/rce/redis/RedisUnauthenticatedCommandExecutionDetectorBootstrapModule.java
+++ b/google/detectors/rce/redis/src/main/java/com/google/tsunami/plugins/detectors/rce/redis/RedisUnauthenticatedCommandExecutionDetectorBootstrapModule.java
@@ -15,9 +15,7 @@
  */
 package com.google.tsunami.plugins.detectors.rce.redis;
 
-import com.google.inject.Provides;
 import com.google.tsunami.plugin.PluginBootstrapModule;
-import javax.net.SocketFactory;
 
 /** A Guice module that bootstraps the {@link RedisUnauthenticatedCommandExecutionDetector}. */
 public final class RedisUnauthenticatedCommandExecutionDetectorBootstrapModule
@@ -26,11 +24,5 @@ public final class RedisUnauthenticatedCommandExecutionDetectorBootstrapModule
   @Override
   protected void configurePlugin() {
     registerPlugin(RedisUnauthenticatedCommandExecutionDetector.class);
-  }
-
-  @Provides
-  @SocketFactoryInstance
-  SocketFactory provideSocketFactory() {
-    return SocketFactory.getDefault();
   }
 }

--- a/google/detectors/rce/redis/src/test/java/com/google/tsunami/plugins/detectors/rce/redis/RedisUnauthenticatedCommandExecutionDetectorTest.java
+++ b/google/detectors/rce/redis/src/test/java/com/google/tsunami/plugins/detectors/rce/redis/RedisUnauthenticatedCommandExecutionDetectorTest.java
@@ -26,9 +26,8 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
-import com.google.inject.Key;
-import com.google.inject.multibindings.OptionalBinder;
 import com.google.protobuf.util.Timestamps;
+import com.google.tsunami.common.net.socket.TsunamiSocketFactory;
 import com.google.tsunami.common.time.testing.FakeUtcClock;
 import com.google.tsunami.common.time.testing.FakeUtcClockModule;
 import com.google.tsunami.proto.AdditionalDetail;
@@ -46,7 +45,6 @@ import java.net.Socket;
 import java.net.SocketTimeoutException;
 import java.time.Instant;
 import javax.inject.Inject;
-import javax.net.SocketFactory;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -60,7 +58,7 @@ public final class RedisUnauthenticatedCommandExecutionDetectorTest {
   private final FakeUtcClock fakeUtcClock =
       FakeUtcClock.create().setNow(Instant.parse("2020-01-01T00:00:00.00Z"));
 
-  private final SocketFactory socketFactoryMock = mock(SocketFactory.class);
+  private final TsunamiSocketFactory socketFactoryMock = mock(TsunamiSocketFactory.class);
 
   @Inject private RedisUnauthenticatedCommandExecutionDetector detector;
 
@@ -71,10 +69,7 @@ public final class RedisUnauthenticatedCommandExecutionDetectorTest {
             new AbstractModule() {
               @Override
               protected void configure() {
-                OptionalBinder.newOptionalBinder(
-                        binder(), Key.get(SocketFactory.class, SocketFactoryInstance.class))
-                    .setBinding()
-                    .toInstance(socketFactoryMock);
+                bind(TsunamiSocketFactory.class).toInstance(socketFactoryMock);
               }
             })
         .injectMembers(this);


### PR DESCRIPTION
Individual testing was performed on a limited set of plugins where testbed setup was straightforward. For the remaining plugins, only `gradle build` was executed.

Depends on changes added by: https://github.com/google/tsunami-security-scanner/pull/149