### PR TITLE
fix(mlflow-fingerprinting): preserve endpoint context in custom-heuristics test assertion

### DIFF
--- a/google/fingerprinters/web/src/test/java/com/google/tsunami/plugins/fingerprinters/web/WebServiceFingerprinterTest.java
+++ b/google/fingerprinters/web/src/test/java/com/google/tsunami/plugins/fingerprinters/web/WebServiceFingerprinterTest.java
@@ -361,11 +361,13 @@ public final class WebServiceFingerprinterTest {
                             ServiceContext.newBuilder()
                                 .setWebServiceContext(
                                     WebServiceContext.newBuilder()
-                                            .setApplicationRoot("/")
+                                        .setApplicationRoot("/")
                                         .setSoftware(
                                             Software.newBuilder()
                                                 .setName(SOFTWARE_IDENTITY_4.getSoftware())))))
                 .build());
+    assertThat(fingerprintingReport.getNetworkServices(0).getNetworkEndpoint())
+        .isEqualTo(endpoint);
   }
 
   private void startMockMlflowWebServer() throws IOException {
@@ -429,6 +431,8 @@ public final class WebServiceFingerprinterTest {
                                         .setApplicationRoot("/")
                                         .setSoftware(Software.newBuilder().setName("MCP Server")))))
                 .build());
+    assertThat(fingerprintingReport.getNetworkServices(0).getNetworkEndpoint())
+        .isEqualTo(endpoint);
   }
 
   @Test
@@ -476,6 +480,8 @@ public final class WebServiceFingerprinterTest {
                                         .setApplicationRoot("/")
                                         .setSoftware(Software.newBuilder().setName("MCP Server")))))
                 .build());
+    assertThat(fingerprintingReport.getNetworkServices(0).getNetworkEndpoint())
+        .isEqualTo(endpoint);
   }
 
   @Test


### PR DESCRIPTION
I have kept application_root path-only ("/") per current schema/behavior, and added explicit NetworkEndpoint equality checks to ensure hostname/IP context is preserved in MLflow and MCP fingerprinting results. Please review it.